### PR TITLE
adding explicit casts

### DIFF
--- a/modules/core/src/edu/kit/iti/algover/script/ast/Operator.java
+++ b/modules/core/src/edu/kit/iti/algover/script/ast/Operator.java
@@ -27,6 +27,7 @@ import edu.kit.iti.algover.script.data.Value;
 
 import java.math.BigInteger;
 import java.util.function.BiFunction;
+import java.util.function.BinaryOperator;
 import java.util.function.UnaryOperator;
 
 
@@ -71,28 +72,28 @@ public enum Operator {
     MULTIPLY("*", "×", 20, Type.INT, Type.INT, Type.INT) {
         @Override
         public Value evaluate(Value... v) {
-            return evaluate(BigInteger::multiply, v);
+            return evaluate((BinaryOperator<BigInteger>)BigInteger::multiply, v);
         }
     },
     /** */
     DIVISION("/", "÷", 20, Type.INT, Type.INT, Type.INT) {
         @Override
         public Value evaluate(Value... v) {
-            return evaluate(BigInteger::divide, v);
+            return evaluate((BinaryOperator<BigInteger>)BigInteger::divide, v);
         }
     },
     /** */
     PLUS("+", 30, Type.INT, Type.INT, Type.INT) {
         @Override
         public Value evaluate(Value... v) {
-            return evaluate(BigInteger::add, v);
+            return Operator.evaluate((BinaryOperator<BigInteger>)BigInteger::add, v);
         }
     },
     /** */
     MINUS("-", 30, Type.INT, Type.INT, Type.INT) {
         @Override
         public Value evaluate(Value... v) {
-            return evaluate(BigInteger::subtract, v);
+            return evaluate((BiFunction<BigInteger,BigInteger,BigInteger>)BigInteger::subtract, v);
         }
     },
     /** */


### PR DESCRIPTION
to avoid compiler errors in eclipse.

The references to the arithmetic operators raised compiler errors in my eclipse version.
Please add these casts to avoid the problem.