### PR TITLE
Filename masking for script filenames

### DIFF
--- a/modules/core/src/edu/kit/iti/algover/project/ProjectManager.java
+++ b/modules/core/src/edu/kit/iti/algover/project/ProjectManager.java
@@ -11,6 +11,7 @@ import edu.kit.iti.algover.script.data.GoalNode;
 import edu.kit.iti.algover.script.interpreter.Interpreter;
 import edu.kit.iti.algover.script.interpreter.InterpreterBuilder;
 import edu.kit.iti.algover.script.parser.Facade;
+import edu.kit.iti.algover.util.Util;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.fxml.LoadException;
 
@@ -153,7 +154,9 @@ public class ProjectManager {
      */
 
     public void findAndParseScriptFile(String pvc) throws IOException {
-        String filePath = project.get().getBaseDir().getAbsolutePath() + pvc + ".script";
+        String maskedFilename = Util.maskFileName(pvc);
+        String filePath = project.get().getBaseDir().getAbsolutePath()
+                + maskedFilename + ".script";
         //find file on disc
         Path p = Paths.get(filePath);
 
@@ -252,6 +255,8 @@ public class ProjectManager {
             //ScriptHelper.visitASTNODE -> String content
             //saveToScriptFile(pvcName, content);
         }
+
+        // REVIEW: When using saveHelper use "Util.maskFileName(pvcName)" here.
 
     }
 

--- a/modules/core/src/edu/kit/iti/algover/util/Util.java
+++ b/modules/core/src/edu/kit/iti/algover/util/Util.java
@@ -9,11 +9,30 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.*;
+import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.RandomAccess;
 import java.util.function.Function;
 
+import edu.kit.iti.algover.proof.PVC;
 
+/**
+ * The Class Util is a collection of general purpose static methods.
+ *
+ * @author mattias ulbrich
+ */
 public final class Util {
+
+
+    private Util() { throw new Error(); }
+
     /**
      * Wrap an immutable list object around an array. The elements in the array
      * can by no means be replaced.
@@ -365,6 +384,41 @@ public final class Util {
             return indexOf(o) != -1;
         }
 
+    }
+
+    /**
+     * Mask a file name to be universally usable on filesystems.
+     *
+     * In particular this is used to mask {@link PVC#getName()}.
+     *
+     * Alphanumeric characters ({@code A-Za-z0-9}) and some other characters are
+     * taken verbatim. Spaces become "-", and "/" becomes "+".
+     *
+     * @param s
+     *            the string to masked
+     * @return the masked string
+     */
+    public static String maskFileName(String s) {
+        StringBuilder sb = new StringBuilder();
+        for(int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            if(   ('0' <= c && c <= '9') || ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')
+               || "_[]().,;".indexOf(c) >= 0 ) {
+                sb.append(c);
+            } else {
+                switch(c) {
+                case ' ': sb.append("-"); break;
+                case '/': sb.append("+"); break;
+                default:
+                    ByteBuffer bb = Charset.forName("UTF-8").encode(Character.toString(c));
+                    while(bb.hasRemaining()) {
+                        sb.append(String.format("%%%02x", bb.get()));
+                    }
+                }
+            }
+        }
+
+        return sb.toString();
     }
 
 

--- a/modules/core/test/edu/kit/iti/algover/util/UtilTest.java
+++ b/modules/core/test/edu/kit/iti/algover/util/UtilTest.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of AlgoVer.
  *
- * Copyright (C) 2015-2016 Karlsruhe Institute of Technology
+ * Copyright (C) 2015-2017 Karlsruhe Institute of Technology
  */
 package edu.kit.iti.algover.util;
 
@@ -11,8 +11,22 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
 public class UtilTest {
+
+    public static String[] parametersForTestMaskFileName() {
+        return new String[] {
+                "abcdefg, abcdefg",
+                "Class/while_true/POST[label2], Class+while_true+POST[label2]",
+                "Class/while_true/POST[label-3], Class+while_true+POST[label%2d3]",
+                "C/if_true/POST[with spaces], C+if_true+POST[with-spaces]",
+        };
+    }
 
     @Test
     public void testReadOnlyArrayListEArray() {
@@ -24,6 +38,11 @@ public class UtilTest {
         assertEquals("[Some, words, in, an, array]", list.toString());
         assertTrue(Arrays.equals(array, list.toArray(new String[0])));
 
+    }
+
+    @Test @Parameters
+    public void testMaskFileName(String filename, String expected) {
+        assertEquals(expected, Util.maskFileName(filename));
     }
 
 


### PR DESCRIPTION
As discussed make PVCs filename compatible

```
    /**
     * Mask a file name to be universally usable on filesystems.
     *
     * In particular this is used to mask {@link PVC#getName()}.
     *
     * Alphanumeric characters ({@code A-Za-z0-9}) and some other characters are
     * taken verbatim. Spaces become "-", and "/" becomes "+".
     *
     * @param s
     *            the string to masked
     * @return the masked string
     */
    public static String maskFileName(String s) {
```