### PR TITLE
Stub proof objects with a Sequent that dont have a proof script file

### DIFF
--- a/modules/core/src/edu/kit/iti/algover/project/ProjectManager.java
+++ b/modules/core/src/edu/kit/iti/algover/project/ProjectManager.java
@@ -142,10 +142,19 @@ public class ProjectManager {
      */
     protected void initializeProofDataStructures(String pvc) throws IOException {
         Proof p = allProofs.get(pvc);
-        findAndParseScriptFileForPVC(pvc);
-        PVC pvcObject = allStrippedPVCs.get(pvc);
-        p.setProofRoot(new ProofNode(null, null, null, pvcObject.getSequent(), pvcObject));
-        buildIndividualInterpreter(p);
+        try {
+            // Either the script file can be loaded, then that file is used for building the proof object
+            findAndParseScriptFileForPVC(pvc);
+            PVC pvcObject = allStrippedPVCs.get(pvc);
+            p.setProofRoot(new ProofNode(null, null, null, pvcObject.getSequent(), pvcObject));
+            buildIndividualInterpreter(p);
+        } catch (IOException e) {
+            // Or the proof object is simply stubbed
+            PVC pvcObject = allStrippedPVCs.get(pvc);
+            p.setProofRoot(new ProofNode(null, null, null, pvcObject.getSequent(), pvcObject));
+            // rethrow
+            throw e;
+        }
 
 
     }


### PR DESCRIPTION
Wie die commit-message schon sagt:
> Stub proof objects with a Sequent, even if there exist no proof scripts for the PVC.

Das Problem, das bei mir Auftrat war, dass, wenn das Projekt neu ist (also noch keine Proof Scripts für die PVCs existieren) und ich es mit dem ProjectManager lade, dann sind in den Proofs von `getProofForPVC(...)` die Sequents `null`. Das fixt dieser PR.

Ich rethrowe die IOException am Ende, falls sie auftrat, um möglichst nah am Verhalten von vorher zu bleiben.

PS: Das ist ein PR, weil ich nicht einfach so auf deinen Brach pushen wollte, @sgrebing 