### PR TITLE
Refactoring the parameter definition and evaluation design

### DIFF
--- a/HEADER
+++ b/HEADER
@@ -1,5 +1,5 @@
 /*
  * This file is part of AlgoVer.
  *
- * Copyright (C) 2015-2017 Karlsruhe Institute of Technology
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
  */

--- a/modules/core/src/edu/kit/iti/algover/rules/AbstractProofRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/AbstractProofRule.java
@@ -1,46 +1,88 @@
 /*
  * This file is part of AlgoVer.
  *
- * Copyright (C) 2015-2017 Karlsruhe Institute of Technology
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
  */
 package edu.kit.iti.algover.rules;
 
-import edu.kit.iti.algover.rules.Parameters.TypedValue;
-
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import edu.kit.iti.algover.term.Term;
+
+/**
+ * This class should serve as base class for all {@link ProofRule} implementations.
+ *
+ * Its main feature is the possibility to check actual arguments against the formal parameters.
+ *
+ * @author Mattias Ulbrich
+ */
 public abstract class AbstractProofRule implements ProofRule {
 
-    private Map<String, Class<?>> requiredParameters;
-    private Map<String, Class<?>> optionalParameters;
+    /**
+     * The parameter for "on" is very common for rules.
+     */
+    public static final ParameterDescription<Term> ON_PARAM =
+            new ParameterDescription<>("on", ParameterType.TERM, true);
 
-    public AbstractProofRule(Map<String, Class<?>> requiredParameters, Map<String, Class<?>> optionalParameters) {
-        this.requiredParameters = requiredParameters;
-        this.optionalParameters = optionalParameters;
+    /**
+     * The parameter "deep" is used for propositional rules that
+     * are to be applied exhaustively.
+     */
+    public static final ParameterDescription<Boolean> DEEP_PARAM =
+            new ParameterDescription<>("deep", ParameterType.BOOLEAN, false);
+
+    /**
+     * This map captures the parameters made
+     * known to the class in the constructor.
+     */
+    private final Map<String, ParameterDescription<?>> allParameters = new HashMap<>();
+
+
+    /**
+     * Instantiate a new object.
+     *
+     * @param parameters a list of all parameters that this proof rule accepts.
+     */
+    public AbstractProofRule(ParameterDescription<?>... parameters) {
+        for (ParameterDescription<?> p : parameters) {
+            allParameters.put(p.getName(), p);
+        }
     }
 
+    /**
+     * Check the actual parameters obtained as method parameter against the formal parameters stored
+     * in {@link #allParameters},
+     *
+     * @param parameters the map of parameters against values.
+     * @throws RuleException if a required parameter has been omitted or an unknown parameter has
+     *                       been used
+     */
     protected final void checkParameters(Parameters parameters) throws RuleException {
-        Set<String> required = new HashSet<>(requiredParameters.keySet());
-        for (Map.Entry<String, TypedValue<?>> en : parameters.entrySet()) {
-            Class<?> t = requiredParameters.get(en.getKey());
-            if (t == null) {
-                t = optionalParameters.get(en.getKey());
+        Set<ParameterDescription<?>> required = new HashSet<>();
+        for (ParameterDescription<?> p : allParameters.values()) {
+            if(p.isRequired()) {
+                required.add(p);
             }
+        }
+
+        for (Map.Entry<String, Object> en : parameters.entrySet()) {
+            ParameterDescription<?> t = allParameters.get(en.getKey());
 
             if (t == null) {
                 throw new RuleException("Unknown parameter '" + en.getKey() + "'");
             }
 
-            TypedValue<?> value = en.getValue();
-            if (!value.isType(t)) {
+            Object value = en.getValue();
+            if (t.acceptsValue(value)) {
                 throw new RuleException(
-                        "Parameter " + en.getKey() + " has type " + value.getType() +
-                                ", but I expected " + t);
+                        "ParameterDescription " + en.getKey() + " has class " + value.getClass() +
+                                ", but I expected " + t + " (class " + t.getType() + ")");
             }
 
-            required.remove(en.getKey());
+            required.remove(t);
         }
 
         if (!required.isEmpty()) {

--- a/modules/core/src/edu/kit/iti/algover/rules/ParameterDescription.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/ParameterDescription.java
@@ -1,0 +1,94 @@
+/*
+ * This file is part of AlgoVer.
+ *
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
+ */
+package edu.kit.iti.algover.rules;
+
+import nonnull.NonNull;
+
+/**
+ * Objects of this class contain descriptions of formal parameters to {@link
+ * ProofRule}s.
+ *
+ * Usually parameters are used as static constant fields defined at load-time.
+ *
+ * They provide type-safe access to elements in a {@link Parameters} object if
+ * their values have been checked beforehand using {@link
+ * AbstractProofRule#checkParameters(Parameters)}.
+ *
+ * @param <T> The type of the values used in the parameter. Taken from the
+ *            {@link ParameterType} provided as constructor argument.
+ * @author Mattias Ulbrich
+ * @see ParameterType
+ * @see Parameters
+ */
+public class ParameterDescription<T> {
+
+    /**
+     * The name of the parameter, i.e., the key under which it must be
+     * specified.
+     */
+    private final String name;
+
+    /**
+     * The type of the parameter. Must be one of the constants defined in the
+     * class.
+     */
+    private final ParameterType<T> type;
+
+    /**
+     * Is this a required (true) or optional (false) paramter.
+     */
+    private final boolean required;
+
+    /**
+     * Instantiate a new immutable parameter description.
+     *
+     * @param name key for the parameter
+     * @param type type of the parameter
+     * @param required is the parameter required or optional?
+     */
+    public ParameterDescription(@NonNull String name, @NonNull ParameterType<T> type, boolean required) {
+        super();
+        this.name = name;
+        this.type = type;
+        this.required = required;
+    }
+
+    /**
+     * Check if the given value is compatible with the class type.
+     *
+     * @param value the object to check
+     * @return true iff the value is an instance of the class
+     * in the {@link ParameterType}.
+     */
+    public boolean acceptsValue(Object value) {
+        return type.getType().isInstance(value);
+    }
+
+    /**
+     * Cast the value into the type of parameter.
+     *
+     * @param value the object to cast
+     * @return the same reference as value, but with a different type.
+     * @throws ClassCastException if the object is not null and is not
+     *                            assignable to the type.
+     */
+    public T castValue(Object value) {
+        return type.getType().cast(value);
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isRequired() {
+        return required;
+    }
+
+    public ParameterType<T> getType() {
+        return type;
+    }
+
+}

--- a/modules/core/src/edu/kit/iti/algover/rules/ParameterType.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/ParameterType.java
@@ -1,0 +1,83 @@
+/*
+ * This file is part of AlgoVer.
+ *
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
+ */
+package edu.kit.iti.algover.rules;
+
+import java.math.BigInteger;
+
+import edu.kit.iti.algover.term.Term;
+
+/**
+ * This is an explicit enumeration type. Since type parameters are used, it is
+ * not implemented as an {@link Enum} but as a class with static fields.
+ *
+ * <p> When a new script type is introduced, this class should get a new
+ * constant.
+ *
+ * <p> The only real drawback against {@link Enum}s is that this class does not
+ * support switch-case-statements.
+ *
+ * @param <T> the Java type which is associated with the script type
+ */
+public class ParameterType<T> {
+
+    /**
+     * The type to capture terms in parameters in scripts
+     */
+    public static final ParameterType<Term> TERM =
+            new ParameterType<>("Term", Term.class);
+
+    /**
+     * The type to capture integers in parameters in scripts
+     */
+    public static final ParameterType<BigInteger> INTEGER =
+            new ParameterType<>("Integer", BigInteger.class);
+
+    /**
+     * The type to capture booleans in parameters in scripts
+     */
+    public static final ParameterType<Boolean> BOOLEAN =
+            new ParameterType<>("Boolean", Boolean.class);
+
+    /**
+     * The type to capture strings in parameters in scripts
+     */
+    public static final ParameterType<String> STRING =
+            new ParameterType<>("String", String.class);
+
+    /**
+     * The readable name of the parameter type.
+     */
+    private final String name;
+
+    /**
+     * The Java classtype associated with the parameter.
+     */
+    private final Class<T> type;
+
+    /**
+     * Create a new parameter type.
+     *
+     * @param name name of the type to create
+     * @param clzz the associated classtype.
+     */
+    private ParameterType(String name, Class<T> clzz) {
+        this.name = name;
+        this.type = clzz;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Class<T> getType() {
+        return type;
+    }
+
+    @Override
+    public String toString() {
+        return getName();
+    }
+}

--- a/modules/core/src/edu/kit/iti/algover/rules/Parameters.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/Parameters.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of AlgoVer.
  *
- * Copyright (C) 2015-2017 Karlsruhe Institute of Technology
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
  */
 package edu.kit.iti.algover.rules;
 
@@ -14,13 +14,12 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 /**
- * The Class Parameters is used to provide arguments to
- * {@link ProofRuleApplication}s.
- * <p>
- * It is essentially a map from names (Strings) to typed values
- * {@link TypedValue}.
- * <p>
- * A parameters object can be set immutable ({@link #setImmutable()}). Thus its
+ * The Class Parameters is used to provide concrete arguments to {@link
+ * ProofRuleApplication}s.
+ *
+ * <p> It is essentially a map from names (Strings) to values ({@link Object}).
+ *
+ * <p> An instance can be set immutable ({@link #setImmutable()}). Thus its
  * state cannot be modified any more and the object can be embedded into an
  * immutable data structure. Method {@link #isMutable()} can be used to check if
  * an object is still mutable.
@@ -40,9 +39,10 @@ public class Parameters {
     }
 
     /**
-     * The storage mapping variable names to typed values.
+     * The storage mapping variable names to values.
      */
-    private final Map<String, TypedValue<?>> valueMap;
+    private final Map<String, Object> valueMap;
+
     /**
      * The mutability flag. Can never be set back to true once set to false.
      */
@@ -57,6 +57,7 @@ public class Parameters {
 
     /**
      * Instantiates a new parameter mapping from another mapping.
+     *
      * <p>
      * It copies all entries from the argument.
      * The created object is is immutable.
@@ -70,14 +71,35 @@ public class Parameters {
     /**
      * Gets a value from the mapping.
      *
-     * @param key the key to look up
+     * @param key
+     *            the key to look up
+     * @return the value stored for that variable, <code>null</code> if no such
+     *         value
+     */
+    public @Nullable Object getValue(@NonNull String key) {
+        return valueMap.get(key);
+    }
+
+    /**
+     * Gets a value from the mapping.
+     *
+     * The key to look up is taken from the name in the parameter description
+     * via {@link ParameterDescription#getName()}.
+     *
+     * @param param the parameter description to look up.
      * @return the value stored for that variable, <code>null</code> if no such
      * value
+     * @throws ClassCastException if the value is not assign-compatible with the
+     *                            type in the parameter description.
      */
-    public
-    @Nullable
-    TypedValue<?> getValue(@NonNull String key) {
-        return valueMap.get(key);
+    public @Nullable <T> T getValue(@NonNull ParameterDescription<T> param) {
+        Object value = valueMap.get(param.getName());
+        if(value != null) {
+            assert param.acceptsValue(value) :
+                "This should have been checked way earlier! (see AbstractProofRule#checkParameters)";
+            return param.castValue(value);
+        }
+        return null;
     }
 
     /**
@@ -86,7 +108,7 @@ public class Parameters {
      * @param key   the variable name
      * @param value the value to store.
      */
-    public void putValue(@NonNull String key, @NonNull TypedValue<?> value) {
+    public void putValue(@NonNull String key, @NonNull Object value) {
         if (!isMutable()) {
             throw new IllegalStateException("These parameters are immutable");
         }
@@ -114,116 +136,8 @@ public class Parameters {
      *
      * @return the immutable set of entries to the object.
      */
-    public Set<Entry<String, TypedValue<?>>> entrySet() {
+    public Set<Entry<String, Object>> entrySet() {
         return valueMap.entrySet();
     }
 
-    /**
-     * The Class TypedValue captures a value together with its target type.
-     * This class is not mutable.
-     * <p>
-     * Use {@link #set(E value)} to obtain a new {@link TypedValue} with
-     * a modified value.
-     *
-     * @param <E> the element type
-     */
-    public static final class TypedValue<E> {
-
-        /**
-         * The type object as its {@link Class} object.
-         */
-        private
-        @NonNull
-        Class<E> type;
-
-        /**
-         * The value
-         */
-        private
-        @Nullable
-        E value;
-
-        /**
-         * Instantiates a new typed value.
-         *
-         * @param type  the type
-         * @param value the value
-         */
-        public TypedValue(@NonNull Class<E> type, @Nullable E value) {
-            this.type = type;
-            this.value = value;
-        }
-
-        /**
-         * Instantiate a new <code>null</code>-valued instance.
-         *
-         * @param <E>  the element type
-         * @param type the type
-         * @return the typed value containing <code>null</code> as value
-         */
-        public static <E> TypedValue<E> nullValue(Class<E> type) {
-            return new TypedValue<E>(type, null);
-        }
-
-        /**
-         * Gets the value, <code>null</code> if that is set.
-         *
-         * @return the value
-         */
-        public
-        @Nullable
-        E getValue() {
-            return value;
-        }
-
-        /**
-         * Gets the type of this value.
-         *
-         * @return the corresponding class object
-         */
-        public Class<E> getType() {
-            return type;
-        }
-
-        /**
-         * Checks if this object is of a type.
-         * <p>
-         * Caution: It is checked whether the types are <em>exactly</em> the
-         * same. Subtype relations are not checked here.
-         *
-         * @param otherType the other type to check against
-         * @return true, if is this's type and otherType are the same
-         */
-        public boolean isType(Class<?> otherType) {
-            return getType() == otherType;
-        }
-
-        /**
-         * Cast this typed value into one which has a known type parameter.
-         * <p>
-         * Due to the class' design, this method is type safe. Use it like
-         * <p>
-         * <pre>
-         * TypeValue<?> tv;
-         * // ... obtain from somewhere w/o knowing its type parameter
-         * if (tv.isType(String.class)) {
-         *     TypeValue<String> sv = tv.cast(String.class);
-         *     String string = sv.getValue();
-         * }
-         * </pre>
-         *
-         * @param <F>       the type to cast to
-         * @param otherType the class type into which it is to be cast
-         * @return <code>this</code> but potentially with a different static
-         * type
-         */
-        @SuppressWarnings("unchecked")
-        public <F> TypedValue<F> cast(Class<F> otherType) {
-            if (otherType == type) {
-                return (TypedValue<F>) this;
-            } else {
-                throw new ClassCastException();
-            }
-        }
-    }
 }

--- a/modules/core/src/edu/kit/iti/algover/rules/impl/FakeSMTSolverRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/impl/FakeSMTSolverRule.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of AlgoVer.
  *
- * Copyright (C) 2015-2017 Karlsruhe Institute of Technology
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
  */
 package edu.kit.iti.algover.rules.impl;
 
@@ -20,7 +20,7 @@ import java.util.Collections;
 public class FakeSMTSolverRule extends AbstractProofRule {
 
     public FakeSMTSolverRule() {
-        super(Collections.emptyMap(), Collections.emptyMap());
+        super();
     }
 
     @Override

--- a/modules/core/src/edu/kit/iti/algover/rules/impl/LetSubstitutionRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/impl/LetSubstitutionRule.java
@@ -1,3 +1,8 @@
+/*
+ * This file is part of AlgoVer.
+ *
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
+ */
 package edu.kit.iti.algover.rules.impl;
 
 import edu.kit.iti.algover.proof.ProofNode;
@@ -28,13 +33,7 @@ public class LetSubstitutionRule extends AbstractProofRule {
      * That term <strong>must</strong> be a let term.
      */
     public LetSubstitutionRule() {
-        super(makeRequiredParameters(), Collections.emptyMap());
-    }
-
-    private static Map<String, Class<?>> makeRequiredParameters() {
-        Map<String, Class<?>> params = new HashMap<>();
-        params.put("on", Term.class);
-        return params;
+        super(ON_PARAM);
     }
 
     @Override
@@ -65,7 +64,7 @@ public class LetSubstitutionRule extends AbstractProofRule {
     public ProofRuleApplication makeApplication(ProofNode target, Parameters parameters) throws RuleException {
         checkParameters(parameters);
 
-        Term on = parameters.getValue("on").cast(Term.class).getValue();
+        Term on = parameters.getValue(ON_PARAM);
 
         if (!(on instanceof LetTerm)) {
             throw new RuleException("Given Term is not a let term");

--- a/modules/core/src/edu/kit/iti/algover/rules/impl/PropositionalExpansionRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/impl/PropositionalExpansionRule.java
@@ -1,3 +1,8 @@
+/*
+ * This file is part of AlgoVer.
+ *
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
+ */
 package edu.kit.iti.algover.rules.impl;
 
 import java.util.ArrayList;
@@ -23,19 +28,7 @@ import edu.kit.iti.algover.term.Term;
 public class PropositionalExpansionRule extends AbstractProofRule {
 
     public PropositionalExpansionRule() {
-        super(makeRequiredParameters(), makeOptionalParameters());
-    }
-
-    private static Map<String, Class<?>> makeRequiredParameters() {
-        Map<String, Class<?>> result = new HashMap<>();
-        result.put("on", Term.class);
-        return result;
-    }
-
-    private static Map<String, Class<?>> makeOptionalParameters() {
-        Map<String, Class<?>> result = new HashMap<>();
-        result.put("deep", Boolean.class);
-        return result;
+        super(ON_PARAM, DEEP_PARAM);
     }
 
     @Override

--- a/modules/core/src/edu/kit/iti/algover/rules/impl/RemoveAssumptionRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/impl/RemoveAssumptionRule.java
@@ -1,3 +1,8 @@
+/*
+ * This file is part of AlgoVer.
+ *
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
+ */
 package edu.kit.iti.algover.rules.impl;
 
 import edu.kit.iti.algover.proof.ProofFormula;
@@ -11,7 +16,7 @@ import java.util.Collections;
 public class RemoveAssumptionRule extends AbstractProofRule {
 
     public RemoveAssumptionRule() {
-        super(Collections.singletonMap("on", Term.class), Collections.emptyMap());
+        super(ON_PARAM);
     }
 
     @Override
@@ -41,7 +46,7 @@ public class RemoveAssumptionRule extends AbstractProofRule {
 
         checkParameters(parameters);
 
-        Term toDelete = parameters.getValue("on").cast(Term.class).getValue();
+        Term toDelete = parameters.getValue(ON_PARAM);
 
         builder.newBranch()
                 .addDeletionsAntecedent(Collections.singletonList(new ProofFormula(toDelete)));

--- a/modules/core/src/edu/kit/iti/algover/rules/impl/TestTrueAssumption.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/impl/TestTrueAssumption.java
@@ -1,3 +1,8 @@
+/*
+ * This file is part of AlgoVer.
+ *
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
+ */
 package edu.kit.iti.algover.rules.impl;
 
 import edu.kit.iti.algover.data.BuiltinSymbols;
@@ -13,7 +18,7 @@ import java.util.HashMap;
 public class TestTrueAssumption extends AbstractProofRule {
 
     public TestTrueAssumption() {
-        super(new HashMap<>(), new HashMap<>());
+        super();
     }
 
     @Override

--- a/modules/core/src/edu/kit/iti/algover/rules/impl/TrivialAndRight.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/impl/TrivialAndRight.java
@@ -1,7 +1,7 @@
 /*
  * This file is part of AlgoVer.
  *
- * Copyright (C) 2015-2017 Karlsruhe Institute of Technology
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
  */
 package edu.kit.iti.algover.rules.impl;
 
@@ -28,7 +28,7 @@ import edu.kit.iti.algover.util.RuleUtil;
 public class TrivialAndRight extends AbstractProofRule {
 
     public TrivialAndRight() {
-        super(makeRequiredParameters(), makeOptionalParameters());
+        super(ON_PARAM, DEEP_PARAM);
     }
 
     private static Map<String, Class<?>> makeOptionalParameters() {
@@ -83,10 +83,7 @@ public class TrivialAndRight extends AbstractProofRule {
     @Override
     public ProofRuleApplication makeApplication(ProofNode target, Parameters parameters) throws RuleException {
         checkParameters(parameters);
-        Parameters.TypedValue<?> onValue = parameters.getValue("on");
-        //TODO what type should on have???
-        // System.out.println(onValue.getType());
-        Term on = onValue.cast(Term.class).getValue();
+        Term on = parameters.getValue(ON_PARAM);
         ProofRuleApplicationBuilder builder = new ProofRuleApplicationBuilder(this);
 
         if(!(on instanceof ApplTerm)) {

--- a/modules/core/src/edu/kit/iti/algover/script/callhandling/ProofRuleHandler.java
+++ b/modules/core/src/edu/kit/iti/algover/script/callhandling/ProofRuleHandler.java
@@ -146,19 +146,15 @@ public class ProofRuleHandler implements CommandHandler<ProofNode> {
 
 
 
-    private Parameters.TypedValue convertValuesToTypedValues(Value val) {
+    private Object convertValuesToTypedValues(Value val) {
         switch (val.getType()) {
             case STRING:
-                return new Parameters.TypedValue(String.class, val.getData());
             case INT:
-                return new Parameters.TypedValue(BigInteger.class, val.getData());
             case TERM:
-                return new Parameters.TypedValue(Term.class, val.getData());
-            //TODO SemiSequent
-            default:
-                System.out.println("Not implemented yet");
-                return null;
+                return val.getData();
 
+            default:
+                throw new Error("not implemented yet");
         }
     }
 

--- a/modules/core/test/edu/kit/iti/algover/rules/TestRuleApplicator.java
+++ b/modules/core/test/edu/kit/iti/algover/rules/TestRuleApplicator.java
@@ -1,3 +1,8 @@
+/*
+ * This file is part of AlgoVer.
+ *
+ * Copyright (C) 2015-2018 Karlsruhe Institute of Technology
+ */
 package edu.kit.iti.algover.rules;
 
 import edu.kit.iti.algover.data.BuiltinSymbols;
@@ -90,7 +95,7 @@ public class TestRuleApplicator {
 
         TermSelector ts = new TermSelector(TermSelector.SequentPolarity.SUCCEDENT, 1);
         Parameters params = new Parameters();
-        params.putValue("on", new Parameters.TypedValue<>(Term.class, term3));
+        params.putValue("on", term3);
 
         //System.out.println(pr.makeApplication(pn, params));
         //RuleApplicator.applyRule(prApp, new ProofNode(null, null, null, testSequent, null));


### PR DESCRIPTION
As discussed a week ago, the parameter passing has been refactored.

* Values are now Objects not TypedValue instances.
* Parameters are now described in their own class ParameterDescription which allows for typesafe value access
* ParameterType is the (homemade) enumeration type for supported types.

This addresses #30 which should be closed if this here goes to master.