### PR TITLE
refactoring empty set/seq with a fixed type.

### DIFF
--- a/modules/core/src/edu/kit/iti/algover/data/BuiltinSymbols.java
+++ b/modules/core/src/edu/kit/iti/algover/data/BuiltinSymbols.java
@@ -178,9 +178,8 @@ public class BuiltinSymbols extends MapSymbolTable {
             new FunctionSymbolFamily(
                     new FunctionSymbol("$intersect", SET1, SET1, SET1), 1);
 
-    public static final FunctionSymbolFamily EMPTY_SET =
-            new FunctionSymbolFamily(
-                    new FunctionSymbol("$empty", SET1), 1);
+    public static final FunctionSymbol EMPTY_SET =
+            new FunctionSymbol("$empty", Sort.get("set", Sort.BOTTOM));
 
     public static final FunctionSymbolFamily CARD =
             new FunctionSymbolFamily(
@@ -215,9 +214,8 @@ public class BuiltinSymbols extends MapSymbolTable {
                     new FunctionSymbol("$seq_upd", SEQ1,
                             SEQ1, Sort.INT, FunctionSymbolFamily.VAR1), 1);
 
-    public static final FunctionSymbolFamily SEQ_EMPTY =
-            new FunctionSymbolFamily(
-                    new FunctionSymbol("$seq_empty", SEQ1), 1);
+    public static final FunctionSymbol SEQ_EMPTY =
+            new FunctionSymbol("$seq_empty", Sort.get("seq", Sort.BOTTOM));
 
     public static final FunctionSymbolFamily SEQ_CONS =
             new FunctionSymbolFamily(

--- a/modules/core/src/edu/kit/iti/algover/term/Sort.java
+++ b/modules/core/src/edu/kit/iti/algover/term/Sort.java
@@ -101,6 +101,13 @@ public class Sort {
     public static final Sort UNTYPED_SORT = get("$UNTYPED");
 
     /**
+     * The uninhabited bottom type of the type hierarchy.
+     *
+     * Used for empty sets and sequences ...
+     */
+    public static final Sort BOTTOM = get("$nothing");
+
+    /**
      * The name of the type (w/o arguments).
      */
     private final String name;
@@ -126,6 +133,7 @@ public class Sort {
         BUILTIN_SORT_NAMES.add("array3");
         BUILTIN_SORT_NAMES.add("field");
         BUILTIN_SORT_NAMES.add("heap");
+        BUILTIN_SORT_NAMES.add("$nothing");
     }
 
     /**
@@ -318,6 +326,10 @@ public class Sort {
         }
 
         if(equals(UNTYPED_SORT)) {
+            return true;
+        }
+
+        if (equals(BOTTOM) && !other.equals(UNTYPED_SORT)) {
             return true;
         }
 

--- a/modules/core/src/edu/kit/iti/algover/term/builder/TreeTermTranslator.java
+++ b/modules/core/src/edu/kit/iti/algover/term/builder/TreeTermTranslator.java
@@ -30,7 +30,6 @@ import edu.kit.iti.algover.util.FunctionWithException;
 import edu.kit.iti.algover.util.HistoryMap;
 import edu.kit.iti.algover.util.ImmutableList;
 import edu.kit.iti.algover.util.Pair;
-import edu.kit.iti.algover.util.TreeUtil;
 import nonnull.NonNull;
 import org.antlr.runtime.CommonToken;
 
@@ -41,7 +40,6 @@ import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
 
 /**
  * The Class TreeTermTranslator is used to create a {@link Term} object from a
@@ -768,26 +766,13 @@ public class TreeTermTranslator {
     }
 
     // can be reused by set, seq and multiset
-    private Term buildExtension(FunctionSymbolFamily emptyFamily,
+    private Term buildExtension(FunctionSymbol empty,
                                 FunctionSymbolFamily addFamily,
                                 DafnyTree tree) throws TermBuildException {
-        Sort sort;
-
-        // May have been resolved during type resolution.
-        DafnyTree expType = tree.getExpressionType();
-        if (expType == null) {
-            if(tree.getChildCount() == 0) {
-                throw new TermBuildException("Currently empty list and set " +
-                        "are not supported via extensions");
-            }
-            sort = null;
-        } else {
-            sort = ASTUtil.toSort(expType).getArgument(0);
-        }
-
 
         List<Term> arguments = new ArrayList<>();
 
+        Sort sort = null;
         for (DafnyTree child : tree.getChildren()) {
             Term term = build(child);
             arguments.add(term);
@@ -800,7 +785,6 @@ public class TreeTermTranslator {
         }
 
         FunctionSymbol add = symbolTable.getFunctionSymbol(addFamily, sort);
-        FunctionSymbol empty = symbolTable.getFunctionSymbol(emptyFamily, sort);
 
         ApplTerm result = new ApplTerm(empty);
         for (Term term : arguments) {

--- a/modules/core/src/edu/kit/iti/algover/term/prettyprint/ExtensionsPrinterExtension.java
+++ b/modules/core/src/edu/kit/iti/algover/term/prettyprint/ExtensionsPrinterExtension.java
@@ -65,10 +65,10 @@ public class ExtensionsPrinterExtension implements PrettyPrintExtension {
         PrettyPrintLayouter pp = prettyPrintVisitor.getPrinter();
 
         // The base case symbol decides on the
-        if (isInstanceOf(fs, BuiltinSymbols.EMPTY_SET)) {
+        if (fs.equals(BuiltinSymbols.EMPTY_SET)) {
             open = "{";
             close = "}";
-        } else if (isInstanceOf(fs, BuiltinSymbols.SEQ_EMPTY)) {
+        } else if (fs.equals(BuiltinSymbols.SEQ_EMPTY)) {
             open = "[";
             close = "]";
         } else {

--- a/modules/core/test/edu/kit/iti/algover/term/SortTest.java
+++ b/modules/core/test/edu/kit/iti/algover/term/SortTest.java
@@ -44,6 +44,7 @@ public class SortTest {
 
     public Object[][] parametersForTestHierarchy() {
         return new Object[][] {
+            // top, bottom, expected
             { Sort.OBJECT, Sort.NULL, true },
             { Sort.OBJECT, Sort.OBJECT, true },
             { Sort.OBJECT, CLASS_SORT, true },
@@ -64,6 +65,16 @@ public class SortTest {
             { Sort.OBJECT, Sort.UNTYPED_SORT, true },
             { CLASS_SORT, Sort.UNTYPED_SORT, true },
             { Sort.UNTYPED_SORT, CLASS_SORT, false },
+
+            { Sort.BOTTOM, Sort.BOTTOM, true},
+            { Sort.BOTTOM, Sort.INT, false},
+            { Sort.INT, Sort.BOTTOM, true},
+            { Sort.BOTTOM, CLASS_SORT, false},
+            { CLASS_SORT, Sort.BOTTOM, true},
+            { Sort.BOTTOM, Sort.NULL, false},
+            { Sort.NULL, Sort.BOTTOM, true},
+            { Sort.BOTTOM, Sort.UNTYPED_SORT, true},
+            { Sort.UNTYPED_SORT, Sort.BOTTOM, false},
         };
     }
 
@@ -77,7 +88,9 @@ public class SortTest {
             { CLASS_SORT, OTHER_CLASS_SORT, Sort.OBJECT },
             { INT_ARRAY, CLASS_SORT, Sort.OBJECT },
             { INT_ARRAY, Sort.NULL, INT_ARRAY },
-            { Sort.INT, Sort.OBJECT, null }
+            { Sort.INT, Sort.OBJECT, null },
+            { Sort.UNTYPED_SORT, Sort.BOTTOM, Sort.BOTTOM},
+            { Sort.UNTYPED_SORT, CLASS_SORT, CLASS_SORT},
         };
     }
 

--- a/modules/core/test/edu/kit/iti/algover/term/builder/SSASequenterTest.java
+++ b/modules/core/test/edu/kit/iti/algover/term/builder/SSASequenterTest.java
@@ -60,10 +60,10 @@ public class SSASequenterTest extends SequenterTest {
                     "  }}";
 
     private static String SSA_EXPECTED[] = {
-            "$eq<set<object>>($mod_1, $empty<object>), " +
+            "$eq<set<object>>($mod_1, $empty), " +
                     "$eq<int>($decr_1, 0), $eq<int>(a, 42) " +
                     "|- $eq<int>($plus(a, r), 0)",
-            "$eq<set<object>>($mod_1, $empty<object>), " +
+            "$eq<set<object>>($mod_1, $empty), " +
                     "$eq<int>($decr_1, 0), " +
                     "$eq<int>($decr_1_1, a_1), " +
                     "$eq<int>(local_2, r_1), " +
@@ -73,7 +73,7 @@ public class SSASequenterTest extends SequenterTest {
                     "$eq<int>(a, 42), " +
                     "$eq<int>($plus(a_1, r_1), 0), " +
                     "$gt(a_1, 0) |- $eq<int>($plus(a_2, r_2), 0)",
-            "$eq<set<object>>($mod_1, $empty<object>), " +
+            "$eq<set<object>>($mod_1, $empty), " +
                     "$eq<int>($decr_1, 0), " +
                     "$eq<int>(a, 42), " +
                     "$eq<int>($plus(a_1, r_1), 0), " +
@@ -114,7 +114,7 @@ public class SSASequenterTest extends SequenterTest {
 
 
     private static String SSA_LINEAR_EXPECTED =
-            "$eq<set<object>>($mod_1, $empty<object>), $eq<int>($decr_1, 0), " +
+            "$eq<set<object>>($mod_1, $empty), $eq<int>($decr_1, 0), " +
                     "$eq<int>(local_1, 0), " +
                     "$eq<int>(r_1, $plus(local_1, 1)), " +
                     "$eq<int>(local_2, $plus(r_1, 1)), " +

--- a/modules/core/test/edu/kit/iti/algover/term/builder/TreeTermTranslatorTest.java
+++ b/modules/core/test/edu/kit/iti/algover/term/builder/TreeTermTranslatorTest.java
@@ -169,12 +169,16 @@ public class TreeTermTranslatorTest {
             // Set, Seqs and cardinalities
             { "|mod|", "$set_card<object>(mod)" },
             { "|iseq|", "$seq_len<int>(iseq)" },
-            { "{1,2,3}", "$set_add<int>(3, $set_add<int>(2, $set_add<int>(1, $empty<int>)))" },
-            { "[1,2,3]", "$seq_cons<int>(3, $seq_cons<int>(2, $seq_cons<int>(1, $seq_empty<int>)))" },
+            { "{1,2,3}", "$set_add<int>(3, $set_add<int>(2, $set_add<int>(1, $empty)))" },
+            { "[1,2,3]", "$seq_cons<int>(3, $seq_cons<int>(2, $seq_cons<int>(1, $seq_empty)))" },
             { "iseq + iseq", "$seq_concat<int>(iseq, iseq)" },
             { "mod * mod", "$intersect<object>(mod, mod)" },
             { "mod + mod", "$union<object>(mod, mod)" },
             { "cseq + dseq", "$seq_concat<object>(cseq, dseq)" },
+            { "{}", "$empty" },
+            { "{} == {1}", "$eq<set<int>>($empty, $set_add<int>(1, $empty))" },
+            { "[]", "$seq_empty" },
+            { "[] == [1]", "$eq<seq<int>>($seq_empty, $seq_cons<int>(1, $seq_empty))" },
         };
     }
 

--- a/modules/core/test/edu/kit/iti/algover/term/builder/UpdateSequenterTest.java
+++ b/modules/core/test/edu/kit/iti/algover/term/builder/UpdateSequenterTest.java
@@ -85,7 +85,7 @@ public class UpdateSequenterTest extends SequenterTest {
             { "A.0.0.0.1", "$plus(x, 3)", "(+ x 3)" },
             { "A.0.0.0.1.0", "x", "x" },
             { "A.0.0.0.1.1", "3", "3" },
-            { "A.0.1", "$empty<object>", "SETEX" }, // artificial
+            { "A.0.1", "$empty", "SETEX" }, // artificial
 
             { "S.0", null, null },
             { "S.0.0", null, null },
@@ -108,7 +108,7 @@ public class UpdateSequenterTest extends SequenterTest {
             { "S.0.0.0.1.0", "x", "x" },
             { "S.0.0.0.1.1", "3", "3" },
             { "S.0.0.1", "0", "0" },
-            { "S.0.1", "$empty<object>", "SETEX" } // artificial
+            { "S.0.1", "$empty", "SETEX" } // artificial
         };
     }
 


### PR DESCRIPTION
To address the issue that `{}` could not be parsed at the moment, I introduced a new sort `Sort.BOTTOM` which is below all other sorts (but `Sort.UNTYPED` which is only present for schema entities).

`{}` is now of the symbol `$empty: set<$nothing>`

`[]` is now `$seq_empty: seq<$nothing>`.

This solves the issue mentioned by Sarah @sgrebing in #81.