### PR TITLE
Reference terms

### DIFF
--- a/modules/core/src/edu/kit/iti/algover/rules/TermSelector.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/TermSelector.java
@@ -49,6 +49,23 @@ import nonnull.Nullable;
 public final class TermSelector implements Comparable<TermSelector> {
 
     /**
+     * Indicator to denote left and right hand side of the sequent.
+     */
+    public enum SequentPolarity {
+        ANTECEDENT, SUCCEDENT;
+
+        /**
+         * Gets the opposite polarity.
+         *
+         * @return an non-<code>null</code> object of this class different from
+         * <code>this</code>
+         */
+        public SequentPolarity getOpposite() {
+            return this == ANTECEDENT ? SUCCEDENT : ANTECEDENT;
+        }
+    }
+
+    /**
      * We store the side of the sequent as a constant value.
      */
     private final @NonNull SequentPolarity polarity;
@@ -139,20 +156,10 @@ public final class TermSelector implements Comparable<TermSelector> {
      *            the path to the subterm in the given term
      */
     public TermSelector(SequentPolarity inAntecedent, int termNo, int... path) {
-
-        assert termNo >= 0 && termNo <= Short.MAX_VALUE :
-            "TermSelectors need non-negative short values, but got " + termNo;
-
-        this.polarity = inAntecedent;
-        this.termNumber = (short) termNo;
-
-        // null check is needed, because "new TermSelector(true, 0, null);" is a
-        // valid java expression
-        if(path != null && path.length > 0) {
-            this.subtermSelector = new SubtermSelector(path);
-        } else {
-            this.subtermSelector = EMPTY_SUBTERMSELECTOR;
-        }
+        this(inAntecedent, termNo,
+                path == null || path.length == 0 ?
+                        EMPTY_SUBTERMSELECTOR :
+                        new SubtermSelector(path));
     }
 
     /**
@@ -538,21 +545,4 @@ public final class TermSelector implements Comparable<TermSelector> {
         return subtermSelector;
     }
 
-
-    /**
-     * Indicator to denote left and right hand side of the sequent.
-     */
-    public enum SequentPolarity {
-        ANTECEDENT, SUCCEDENT;
-
-        /**
-         * Gets the opposite polarity.
-         *
-         * @return an non-<code>null</code> object of this class different from
-         * <code>this</code>
-         */
-        public SequentPolarity getOpposite() {
-            return this == ANTECEDENT ? SUCCEDENT : ANTECEDENT;
-        }
-    }
 }

--- a/modules/core/src/edu/kit/iti/algover/rules/impl/AndLeftRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/impl/AndLeftRule.java
@@ -13,6 +13,8 @@ import edu.kit.iti.algover.proof.ProofNode;
 import edu.kit.iti.algover.rules.*;
 import edu.kit.iti.algover.term.ApplTerm;
 import edu.kit.iti.algover.term.FunctionSymbol;
+import edu.kit.iti.algover.term.ReferenceTerm;
+import edu.kit.iti.algover.term.Sequent;
 import edu.kit.iti.algover.term.Term;
 import edu.kit.iti.algover.term.parser.TermParser;
 import edu.kit.iti.algover.util.RuleUtil;
@@ -68,8 +70,10 @@ public class AndLeftRule extends DefaultFocusProofRule {
 
         ProofRuleApplicationBuilder builder = new ProofRuleApplicationBuilder(this);
 
-        builder.newBranch().addReplacement(selector, appl.getTerm(0)).
-                addAdditionAntecedent(new ProofFormula(appl.getTerm(1), formula.getLabels()));
+        builder.newBranch().
+                addDeletions(Sequent.singleAntecedent(formula)).
+                addAdditionAntecedent(new ProofFormula(new ReferenceTerm(selector.selectSubterm(0)), formula.getLabels())).
+                addAdditionAntecedent(new ProofFormula(new ReferenceTerm(selector.selectSubterm(1)), formula.getLabels()));
 
         builder.setApplicability(ProofRuleApplication.Applicability.APPLICABLE);
 

--- a/modules/core/src/edu/kit/iti/algover/term/ApplTerm.java
+++ b/modules/core/src/edu/kit/iti/algover/term/ApplTerm.java
@@ -11,22 +11,54 @@ import java.util.List;
 
 import edu.kit.iti.algover.term.builder.TermBuildException;
 import edu.kit.iti.algover.util.Util;
+import nonnull.DeepNonNull;
+import nonnull.NonNull;
 
+/**
+ * A function application term.
+ *
+ * @author Mattias Ulbrich
+ */
 public class ApplTerm extends Term {
 
-    private final FunctionSymbol function;
+    /**
+     * The applied function symbol.
+     */
+    private final @NonNull FunctionSymbol function;
 
-    public ApplTerm(FunctionSymbol function, List<Term> arguments) throws TermBuildException {
-        super(function.getResultSort(),
-                Util.toArray(arguments, Term.class));
+    /**
+     * Create a new function application term. The arguments must match the
+     * function symbol in number and sorts.
+     *
+     * @param function  the symbol to apply
+     * @param arguments non-null arguments to be used
+     * @throws TermBuildException if the arguments cannot go with the symbol
+     */
+    public ApplTerm(@NonNull FunctionSymbol function, @DeepNonNull List<Term> arguments) throws TermBuildException {
+        super(function.getResultSort(), Util.toArray(arguments, Term.class));
         this.function = function;
         check();
     }
 
+    /**
+     * Create a new function application term. The arguments must match the
+     * function symbol in number and sorts.
+     *
+     * @param function  the symbol to apply
+     * @param arguments non-null arguments to be used
+     * @throws TermBuildException if the arguments cannot go with the symbol
+     */
     public ApplTerm(FunctionSymbol function, Term... arguments) throws TermBuildException {
         this(function, Arrays.asList(arguments));
     }
 
+    /**
+     * Create a new constant function application term. The arguments must match
+     * the function symbol in number and sorts.
+     *
+     * @param constant the symbol to apply
+     * @throws TermBuildException if the symbol is not a constant
+     */
     public ApplTerm(FunctionSymbol constant) throws TermBuildException {
         this(constant, Collections.emptyList());
     }

--- a/modules/core/src/edu/kit/iti/algover/term/ReferenceTerm.java
+++ b/modules/core/src/edu/kit/iti/algover/term/ReferenceTerm.java
@@ -1,0 +1,49 @@
+/*
+ * This file is part of DIVE.
+ *
+ * Copyright (C) 2015-2019 Karlsruhe Institute of Technology
+ */
+
+package edu.kit.iti.algover.term;
+
+import edu.kit.iti.algover.rules.RuleException;
+import edu.kit.iti.algover.rules.SubtermSelector;
+import edu.kit.iti.algover.rules.TermParameter;
+import edu.kit.iti.algover.rules.TermSelector;
+
+public class ReferenceTerm extends SchemaTerm {
+
+    private final TermSelector selector;
+
+    public ReferenceTerm(TermSelector selector, Term term) {
+        super(term.getSort(), new Term[] { term });
+        this.selector = selector;
+    }
+
+    // MOVE THESE TWO TO RULEUTIL OR SIMILAR CLASS IN THE RULE INFRASTRUCTURE
+    public static Term select(TermParameter term, int... sub) throws RuleException {
+        return select(term, new SubtermSelector(sub));
+    }
+
+    public static Term select(TermParameter term, SubtermSelector selector) throws RuleException {
+        Term subterm = selector.selectSubterm(term.getTerm());
+        return new ReferenceTerm(new TermSelector(term.getTermSelector(), selector), subterm);
+    }
+
+    @Override
+    public String toString() {
+        // not to be parsed, hence, representation does not really matter
+        return "[" + selector + "](" + getTerm(0).toString() + ")";
+    }
+
+    @Override
+    public <A, R, E extends Exception> R accept(TermVisitor<A, R, E> visitor, A arg) throws E {
+        return visitor.visit(this, arg);
+    }
+
+    @Override
+    public SchemaTerm refineSort(Sort newSort) {
+        // TODO not finished
+        return null;
+    }
+}

--- a/modules/core/src/edu/kit/iti/algover/term/SchemaTerm.java
+++ b/modules/core/src/edu/kit/iti/algover/term/SchemaTerm.java
@@ -5,12 +5,29 @@
  */
 package edu.kit.iti.algover.term;
 
+import nonnull.NonNull;
+
+/**
+ * Schema terms are terms that can be used in matching expressions and can be
+ * used by rules. They are not to occur on the level of concrete sequent
+ * terms.
+ *
+ * @author Mattias Ulbrich
+ */
 public abstract class SchemaTerm extends Term {
 
     public SchemaTerm(Sort sort, Term[] subterms) {
         super(sort, subterms);
     }
 
-    public abstract SchemaTerm refineSort(Sort newSort);
+    /**
+     * Get a term which coincides with this term but with a more concrete type.
+     *
+     * Schematic terms may have placeholder terms that need to be refined later.
+     *
+     * @param newSort the sort to refine to.
+     * @return a term similar to this of sort <code>newSort</code>
+     */
+    public abstract SchemaTerm refineSort(@NonNull Sort newSort);
 
 }

--- a/modules/core/src/edu/kit/iti/algover/term/TermVisitor.java
+++ b/modules/core/src/edu/kit/iti/algover/term/TermVisitor.java
@@ -5,8 +5,6 @@
  */
 package edu.kit.iti.algover.term;
 
-import edu.kit.iti.algover.term.match.MatchException;
-
 public interface TermVisitor<A, R, E extends Exception> {
 
     R visit(VariableTerm variableTerm, A arg) throws E;
@@ -29,9 +27,12 @@ public interface TermVisitor<A, R, E extends Exception> {
         return visitSchemaTerm(schemaCaptureTerm, arg);
     }
 
+    default R visit(ReferenceTerm referenceTerm, A arg) throws E {
+        return visitSchemaTerm(referenceTerm, arg);
+    }
+
     default R visitSchemaTerm(SchemaTerm schemaTerm, A arg) throws E {
         throw new Error("The visitor of type " + getClass() +
                 " must not be applied to schematic terms.");
     }
-
 }

--- a/modules/core/test-res/edu/kit/iti/algover/parser/typingTest.dfy
+++ b/modules/core/test-res/edu/kit/iti/algover/parser/typingTest.dfy
@@ -305,4 +305,11 @@ class C
       setC := { null };
    }
 
+   function f() : int
+     requires intfield > 0
+     reads this, cfield
+   {
+     intfield - 1
+   }
+
 }

--- a/modules/core/test/edu/kit/iti/algover/parser/TypeResolutionTest.java
+++ b/modules/core/test/edu/kit/iti/algover/parser/TypeResolutionTest.java
@@ -5,6 +5,7 @@
  */
 package edu.kit.iti.algover.parser;
 
+import edu.kit.iti.algover.dafnystructures.DafnyFunction;
 import edu.kit.iti.algover.dafnystructures.DafnyMethod;
 import edu.kit.iti.algover.project.Project;
 import edu.kit.iti.algover.project.ProjectBuilder;
@@ -57,6 +58,9 @@ public class TypeResolutionTest {
         List<Object[]> result = new ArrayList<>();
         for (DafnyMethod method : project.getClass("C").getMethods()) {
             result.add(new Object[] { method.getName(), project });
+        }
+        for (DafnyFunction function : project.getClass("C").getFunctions()) {
+            result.add(new Object[] { function.getName(), project });
         }
         // result = Collections.singletonList(new Object[] { "quantifiers", project});
         return result;


### PR DESCRIPTION
Introduce reference term. They can be used to model reference dependencies over rule applications.
They will be removed from the terms before adding them to the sequent. But before they indicate dependencies.

If we apply `swapAdd` on the sequent

    phi |- 0 < x+y

then the proof application would contain the replacement

    S.0.1  ---->  y«S.0.1.1» + x«S.0.1.0»

which allows the reference mapping to track that.

Still needs discussion. Not ready for merge yet. @JonasKlamroth 