### PR TITLE
removing ParameterType.MATCH_TERM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,8 +90,10 @@ subprojects {
         header file("$rootDir/HEADER")
         include "$projectDir/src/**/*.java"
         exclude "$projectDir/gen/**/*.java"
+        mapping {
+            java = "SLASHSTAR_STYLE"
+        }
 
-        //strictCheck true
     }
 
     

--- a/modules/core/src/edu/kit/iti/algover/rules/DefaultFocusProofRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/DefaultFocusProofRule.java
@@ -16,7 +16,7 @@ public abstract class DefaultFocusProofRule extends AbstractProofRule {
      * The on-parameter is an optionl parameter in default-focus rules
      */
     public static ParameterDescription<TermParameter> ON_PARAM_OPT =
-            new ParameterDescription<>("on", ParameterType.MATCH_TERM, false);
+            new ParameterDescription<>("on", ParameterType.TERM, false);
 
     public DefaultFocusProofRule(ParameterDescription<?>... parameters) {
         super(ON_PARAM_OPT, parameters);

--- a/modules/core/src/edu/kit/iti/algover/rules/DefaultFocusProofRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/DefaultFocusProofRule.java
@@ -9,19 +9,45 @@ package edu.kit.iti.algover.rules;
 
 import edu.kit.iti.algover.proof.ProofNode;
 import edu.kit.iti.algover.term.Sequent;
+import nonnull.DeepNonNull;
+import nonnull.Nullable;
 
+/**
+ * Default implementation of the proof rules that focus on a term.
+ *
+ * Here the "on" parameter is mandatory.
+ *
+ * It add default implementations for {@link #considerApplication(ProofNode, Sequent, TermSelector)}
+ * and {@link #makeApplication(ProofNode, Parameters)}
+ *
+ * There is a method {@link #getDefaultOnParameter(ProofNode)} which for all
+ * implementations has to yield the default value for the on parameter (e.g.
+ * '|- _ && _' for andRight).
+ *
+ * @author Mattias Ulbrich
+ *
+ * TODO MERGE THIS WITH FocusProofRule
+ */
 public abstract class DefaultFocusProofRule extends AbstractProofRule {
 
     /**
-     * The on-parameter is an optionl parameter in default-focus rules
+     * The on-parameter is an optional parameter in default-focus rules
      */
-    public static ParameterDescription<TermParameter> ON_PARAM_OPT =
+    public static final ParameterDescription<TermParameter> ON_PARAM_OPT =
             new ParameterDescription<>("on", ParameterType.TERM, false);
 
-    public DefaultFocusProofRule(ParameterDescription<?>... parameters) {
+    /**
+     * Instantiate a new instance with the given set of parameters.
+     *
+     * "on" is always a required parameter for this subclasses of this class.
+     *
+     * @param parameters the list of parameters for this class
+     */
+    public DefaultFocusProofRule(@DeepNonNull ParameterDescription<?>... parameters) {
         super(ON_PARAM_OPT, parameters);
     }
 
+    @Override
     public final ProofRuleApplication considerApplication(ProofNode target, Sequent selection, TermSelector selector) throws RuleException {
 
         try {
@@ -46,5 +72,15 @@ public abstract class DefaultFocusProofRule extends AbstractProofRule {
         return super.makeApplication(target, parameters);
     }
 
-    protected abstract TermParameter getDefaultOnParameter(ProofNode target) throws RuleException;
+    /**
+     * The "on"-parameter is mandatory for focus rules. However, it needs not be
+     * mentioned explicitly in all cases.
+     *
+     * If "on" is omitted, the value returned by this method is used as value.
+     *
+     * @param target the proofnode for which the parameter is created
+     * @return a term parameter containing the default value for "on", null if not supported
+     * @throws RuleException if something goes wrong during computation
+     */
+    protected abstract @Nullable TermParameter getDefaultOnParameter(ProofNode target) throws RuleException;
 }

--- a/modules/core/src/edu/kit/iti/algover/rules/FocusProofRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/FocusProofRule.java
@@ -20,14 +20,17 @@ import edu.kit.iti.algover.term.Sequent;
  * {@link ProofRuleApplication} with {@link edu.kit.iti.algover.rules.ProofRuleApplication.Applicability#INSTANTIATION_REQUIRED}.
  *
  * @author Mattias Ulbrich
+ *
+ * TODO MERGE THIS WITH DefaultFocusProofRule
+ *
  */
 public abstract class FocusProofRule extends AbstractProofRule {
 
     /**
      * The on-parameter is a required parameter in focus rules
      */
-    public static ParameterDescription<TermParameter> ON_PARAM_REQ =
-            new ParameterDescription<>("on", ParameterType.TERM, false);
+    public static final ParameterDescription<TermParameter> ON_PARAM_REQ =
+            new ParameterDescription<>("on", ParameterType.TERM, true);
 
     public FocusProofRule(ParameterDescription<?>... parameters) {
         super(ON_PARAM_REQ, parameters);

--- a/modules/core/src/edu/kit/iti/algover/rules/FocusProofRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/FocusProofRule.java
@@ -27,7 +27,7 @@ public abstract class FocusProofRule extends AbstractProofRule {
      * The on-parameter is a required parameter in focus rules
      */
     public static ParameterDescription<TermParameter> ON_PARAM_REQ =
-            new ParameterDescription<>("on", ParameterType.MATCH_TERM, false);
+            new ParameterDescription<>("on", ParameterType.TERM, false);
 
     public FocusProofRule(ParameterDescription<?>... parameters) {
         super(ON_PARAM_REQ, parameters);

--- a/modules/core/src/edu/kit/iti/algover/rules/NoFocusProofRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/NoFocusProofRule.java
@@ -16,7 +16,7 @@ public abstract class NoFocusProofRule extends AbstractProofRule {
      * the mandatory version of the "on" parameter
      */
     public static final ParameterDescription<TermParameter> ON_PARAM =
-            new ParameterDescription<>("on", ParameterType.MATCH_TERM, true);
+            new ParameterDescription<>("on", ParameterType.TERM, true);
 
     public NoFocusProofRule(ParameterDescription<?>... parameters) {
         super(parameters);

--- a/modules/core/src/edu/kit/iti/algover/rules/ParameterType.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/ParameterType.java
@@ -105,8 +105,19 @@ public abstract class ParameterType<T> {
         return getName();
     }
 
+    /**
+     * Print this the parameter value provided in a nice form, possibly using the provided term
+     * prettyprinter.
+     *
+     * Delimiters are added to the string (e.g. "..." for Strings).
+     *
+     * @param prettyPrint the pretty-printer for terms and sequents
+     * @param value the value to print
+     * @return a String representing the value
+     */
     public abstract String prettyPrint(PrettyPrint prettyPrint, T value);
 
+    // used from TermParameter#prettyPrint.
     private static String prettyPrintTerm(PrettyPrint prettyPrint, TermParameter parameter) {
         String pp;
         // TODO This case distinction is ugly.

--- a/modules/core/src/edu/kit/iti/algover/rules/ParameterType.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/ParameterType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * This file is part of DIVE.
  *
  * Copyright (C) 2015-2019 Karlsruhe Institute of Technology
@@ -26,17 +26,6 @@ import edu.kit.iti.algover.util.Util;
  * @author Mattias Ulbrich
  */
 public abstract class ParameterType<T> {
-
-    /**
-     * The type to capture match-terms in parameters in scripts
-     */
-    public static final ParameterType<TermParameter> MATCH_TERM =
-            new ParameterType<>("MatchTerm", TermParameter.class) {
-                @Override
-                public String prettyPrint(PrettyPrint prettyPrint, TermParameter value) {
-                    return prettyPrintTerm(prettyPrint, value);
-                }
-            };
 
     /**
      * The type to capture terms in parameters in scripts

--- a/modules/core/src/edu/kit/iti/algover/rules/ProofRule.java
+++ b/modules/core/src/edu/kit/iti/algover/rules/ProofRule.java
@@ -113,7 +113,7 @@ public interface ProofRule {
     @SuppressWarnings( "unchecked" )
     public default @Nullable ParameterDescription<TermParameter> getOnParameter() {
         ParameterDescription<?> onParam = getAllParameters().get("on");
-        assert onParam == null || onParam.getType() == ParameterType.MATCH_TERM;
+        assert onParam == null || onParam.getType() == ParameterType.TERM;
         return (ParameterDescription<TermParameter>) onParam;
     }
 }

--- a/modules/core/test/edu/kit/iti/algover/rules/AbstractProofRuleTest.java
+++ b/modules/core/test/edu/kit/iti/algover/rules/AbstractProofRuleTest.java
@@ -32,14 +32,12 @@ public class AbstractProofRuleTest {
             new ParameterDescription<>("optionalString", ParameterType.STRING, false);
     private static final ParameterDescription<TermParameter> OPT_TERM_PARAM =
             new ParameterDescription<>("optionalTerm", ParameterType.TERM, false);
-    private static final ParameterDescription<TermParameter> OPT_M_TERM_PARAM =
-            new ParameterDescription<>("optionalMatchTerm", ParameterType.MATCH_TERM, false);
     public static final TestRule RULE = new TestRule();
 
     private static class TestRule extends NoFocusProofRule {
 
         TestRule() {
-            super(OPT_INT_PARAM, OPT_BOOL_PARAM, OPT_STRING_PARAM, OPT_TERM_PARAM, OPT_M_TERM_PARAM);
+            super(OPT_INT_PARAM, OPT_BOOL_PARAM, OPT_STRING_PARAM, OPT_TERM_PARAM);
         }
 
         @Override
@@ -75,11 +73,10 @@ public class AbstractProofRuleTest {
         ps.putValue(OPT_INT_PARAM, BigInteger.valueOf(42));
         ps.putValue(OPT_STRING_PARAM, "43");
         ps.putValue(OPT_TERM_PARAM, new TermParameter(tb.tt(), s));
-        ps.putValue(OPT_M_TERM_PARAM, new TermParameter(tb.tt(), s));
         prab.setParameters(ps);
 
         assertEquals("testRule optionalBool=true optionalInt=42 " +
-                        "optionalString=\"43\" optionalTerm='true' optionalMatchTerm='true';",
+                        "optionalString=\"43\" optionalTerm='true';",
                 RULE.getTranscript(prab.build()));
     }
 

--- a/modules/fxgui/src/edu/kit/iti/algover/util/RuleParameterDialog.java
+++ b/modules/fxgui/src/edu/kit/iti/algover/util/RuleParameterDialog.java
@@ -113,7 +113,7 @@ public class RuleParameterDialog extends Dialog<Void> {
     }
 
     private Validator<String> getValidatorForType(ParameterType<?> type) {
-        if (type == ParameterType.TERM  || type == ParameterType.MATCH_TERM) {
+        if (type == ParameterType.TERM) {
             return this::termValidator;
         } else if (type == ParameterType.BOOLEAN) {
             return this::booleanValidator;
@@ -130,7 +130,7 @@ public class RuleParameterDialog extends Dialog<Void> {
             String text = tf.getText();
             String label = ((Label) (gridPane.getChildren().get(i * 2))).getText();
             ParameterDescription<?> pd = rule.getAllParameters().get(label);
-            if(tf.getUserData().equals(ParameterType.TERM) || tf.getUserData().equals(ParameterType.MATCH_TERM)) {
+            if(tf.getUserData().equals(ParameterType.TERM)) {
                 try {
                     Term t = termParser.parse(text);
                     parameters.checkAndPutValue(pd, new TermParameter(t, sequent));


### PR DESCRIPTION
As discussed, this static field is no longer needed.