### PR TITLE
improved linebreaks for chained operators

### DIFF
--- a/modules/core/res/edu/kit/iti/algover/term/prettyprint/operators.xml
+++ b/modules/core/res/edu/kit/iti/algover/term/prettyprint/operators.xml
@@ -61,11 +61,13 @@
     <name>$and</name>
     <op>&amp;&amp;</op>
     <precedence>15</precedence>
+    <chaining>true</chaining>
   </operator>
   <operator>
     <name>$or</name>
     <op>||</op>
     <precedence>10</precedence>
+    <chaining>true</chaining>
   </operator>
   <operator>
     <name>$imp</name>

--- a/modules/core/test/edu/kit/iti/algover/term/prettyprint/PrettyPrintTest.java
+++ b/modules/core/test/edu/kit/iti/algover/term/prettyprint/PrettyPrintTest.java
@@ -79,6 +79,18 @@ public class PrettyPrintTest {
             { "! !b1" },
             { "!(b1 && b1)" },
             { "1 != 2" },
+            { "b1 && (b1 && b1)" },
+            { "b1 && b1 && b1" },
+        };
+    }
+
+    public Object[][] parametersForTestWithLinebreak() {
+        return new Object[][] {
+            { "b1 && b1", "   b1\n&& b1", 5 },
+            { "(b1 && b1) && b1", "   b1\n&& b1\n&& b1", 5 },
+            { "(b1 || b1) || b1", "   b1\n|| b1\n|| b1", 5 },
+            { "b1 && (b1 && b1)", "   b1\n&& (   b1\n    && b1)", 7 },
+            { "b1 || b1 && b1",   "   b1\n||    b1\n   && b1", 7 }
         };
     }
 
@@ -195,6 +207,17 @@ public class PrettyPrintTest {
         AnnotatedString printed = new PrettyPrint().print(parsed);
 
         assertEquals(input, printed.toString());
+    }
+
+    @Test @Parameters
+    public void testWithLinebreak(String input, String expected, Integer linewidth)
+             throws DafnyParserException, DafnyException {
+
+        Term parsed = TermParser.parse(st, input);
+        PrettyPrint pp = new PrettyPrint();
+        AnnotatedString printed = pp.print(parsed, linewidth);
+
+        assertEquals(expected, printed.toString());
     }
 
     @Test @Parameters


### PR DESCRIPTION
when combining a series of conjunctions (or disjunctions) prettyprinting is improved now.

Old:
````
      X
   && Y
&& Z
````

New:
````
   X
&& Y
&& Z
`````