### PR TITLE
Dafny editor: idea to match curly braces on enter

### DIFF
--- a/modules/fxgui/ListExample/AlgoVerList.dfy.proofs
+++ b/modules/fxgui/ListExample/AlgoVerList.dfy.proofs
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE properties SYSTEM "http://java.sun.com/dtd/properties.dtd">
 <properties>
-<comment>Created by DIVE at Tue Apr 28 19:51:39 CEST 2020</comment>
+<comment>Created by DIVE at Fri May 22 13:49:57 CEST 2020</comment>
 <entry key="List.removeAt/then/else/Bounds">expand on='... ((?match: this.Valid())) ... |-';
 boogie ;
 
@@ -72,10 +72,17 @@ boogie ;
 boogie ;
 
 </entry>
+<entry key="List.Valid/Reads.14"></entry>
+<entry key="List.Valid/Reads.13"></entry>
+<entry key="List.Valid/Reads.12"></entry>
+<entry key="List.Valid/Reads.11"></entry>
 <entry key="List.removeAt/then/else/Bounds.1">expand on='... ((?match: this.Valid())) ... |-';
 boogie ;
 </entry>
+<entry key="List.Valid/Reads.10"></entry>
 <entry key="List.removeAt/then/else/Bounds.2">boogie;
+</entry>
+<entry key="List.removeAt/then/else/Bounds.3">boogie;
 </entry>
 <entry key="List.getAt/loop_exit/Post">expand on='... ((?match: this.Valid())) ... |-';
 andLeft on='... ((?match: |this.seqq| == |this.nodeseqq| &amp;&amp; |this.seqq| &gt;= 1 &amp;&amp; this.head != null &amp;&amp; (forall n:int :: (n &gt;= 0 &amp;&amp; n &lt; |this.nodeseqq| ==&gt; this.nodeseqq[n] != null)) &amp;&amp; (forall i:int :: (i &gt;= 0 &amp;&amp; i &lt; |this.seqq| ==&gt; this.seqq[i] == this.nodeseqq[i].value)) &amp;&amp; (forall k:int :: (k &gt;= 0 &amp;&amp; k &lt; |this.nodeseqq| - 1 ==&gt; this.nodeseqq[k].next != null)) &amp;&amp; this.nodeseqq[0] == this.head &amp;&amp; this.nodeseqq[(|this.nodeseqq| - 1)].next == null &amp;&amp; (forall j:int :: (j &gt;= 0 &amp;&amp; j &lt; |this.nodeseqq| - 1 ==&gt; this.nodeseqq[j].next == this.nodeseqq[(j + 1)])))) ... |-';
@@ -86,8 +93,11 @@ andLeft on='... ((?match: |this.seqq| == |this.nodeseqq| &amp;&amp; |this.seqq| 
 inst on='(forall i:int :: i &gt;= 0 &amp;&amp; i &lt; |this.seqq| ==&gt; this.seqq[i] == this.nodeseqq[i].value)'
      with='idx₁';
 boogie;</entry>
-<entry key="List.removeAt/then/else/Bounds.3">boogie;
-</entry>
+<entry key="List.Valid/Reads.19"></entry>
+<entry key="List.Valid/Reads.18"></entry>
+<entry key="List.Valid/Reads.17"></entry>
+<entry key="List.Valid/Reads.16"></entry>
+<entry key="List.Valid/Reads.15"></entry>
 <entry key="List.removeAt/else/loop/Null">expand on='... ((?match: this.Valid())) ... |-';
 boogie ;
 </entry>
@@ -97,6 +107,8 @@ boogie ;
 <entry key="List.insertAt/loop_exit/Null">expand on='... ((?match: this.Valid())) ... |-';
 boogie ;
 </entry>
+<entry key="List.Valid/Reads.21"></entry>
+<entry key="List.Valid/Reads.20"></entry>
 <entry key="List.removeAt/else/loop_exit/Post">boogie;
 </entry>
 <entry key="List.removeAt/else/InitInv.1">expand on='... ((?match: this.Valid())) ... |-';
@@ -232,6 +244,7 @@ boogie ;
 <entry key="List.size/loop/Dec"></entry>
 <entry key="List.insertAt/loop/Dec">boogie;
 </entry>
+<entry key="List.Valid/Reads"></entry>
 <entry key="List.insertAt/loop/Inv">boogie;
 </entry>
 <entry key="List.getAt/loop/Null">expand on='... ((?match: this.Valid())) ... |-';
@@ -240,9 +253,15 @@ boogie ;
 <entry key="List.removeAt/else/loop_exit/Null">expand on='... ((?match: this.Valid())) ... |-';
 boogie ;
 </entry>
+<entry key="List.Valid/Reads.9"></entry>
+<entry key="List.Valid/Reads.8"></entry>
 <entry key="List.removeAt/else/loop_exit/else/Null.1">boogie;
 </entry>
+<entry key="List.Valid/Reads.7"></entry>
 <entry key="List.removeAt/else/loop_exit/else/Null.2"></entry>
+<entry key="List.Valid/Reads.6"></entry>
+<entry key="List.Valid/Reads.5"></entry>
+<entry key="List.Valid/Reads.4"></entry>
 <entry key="List.removeAt/else/loop_exit/then/Post.1">expand on='... ((?match: this.Valid())) ... |-';
 substitute on='|- ... ((?match: let node := node₁ :: let $heap := $heap[node.next := node.next.next] :: let $heap := $heap[this.nodeseqq := $seq_sub&lt;Node&gt;(this.nodeseqq@$heap, 0, pos)] :: let $heap := $heap[this.seqq := $seq_sub&lt;int&gt;(this.seqq@$heap, 0, pos)] :: this.Valid()@$heap)) ...';
 substitute on='|- ... ((?match: let $heap := $heap[node₁.next := ((node₁.next).next)] :: let $heap := $heap[this.nodeseqq := $seq_sub&lt;Node&gt;(this.nodeseqq@$heap, 0, pos)] :: let $heap := $heap[this.seqq := $seq_sub&lt;int&gt;(this.seqq@$heap, 0, pos)] :: this.Valid()@$heap)) ...';
@@ -264,9 +283,12 @@ boogie ;
 </entry>
 <entry key="List.insertAt/InitInv">boogie;
 </entry>
+<entry key="List.Valid/Reads.3"></entry>
+<entry key="List.Valid/Reads.2"></entry>
 <entry key="List.insertAt/loop_exit/Post">expand on='... ((?match: this.Valid())) ... |-';
 substitute on='|- ... ((?match: let node := node₁ :: let $heap := $heap[$create($new₁)] :: let newNode := $new₁ :: let $heap := $heap[$anon(let this, value, next := newNode, value, node.next@$heap :: {this}, $aheap₁)] :: let $heap := $heap[node.next := newNode] :: let $heap := $heap[this.nodeseqq := $seq_sub&lt;Node&gt;(this.nodeseqq@$heap, 0, pos) + ([newNode]) + $seq_sub&lt;Node&gt;(this.nodeseqq@$heap, pos, |this.nodeseqq@$heap|)] :: let $heap := $heap[this.seqq := $seq_sub&lt;int&gt;(this.seqq@$heap, 0, pos) + ([value]) + $seq_sub&lt;int&gt;(this.seqq@$heap, pos, |this.seqq@$heap|)] :: this.seqq@$heap == (let $heap := $oldheap :: $seq_sub&lt;int&gt;(this.seqq@$heap, 0, pos) + ([value]) + $seq_sub&lt;int&gt;(this.seqq@$heap, pos, |this.seqq@$heap|)))) ...';
 </entry>
+<entry key="List.Valid/Reads.1"></entry>
 <entry key="List.removeAt/else/loop/Inv">boogie;
 </entry>
 </properties>

--- a/modules/fxgui/src/edu/kit/iti/algover/editor/DafnyCodeArea.java
+++ b/modules/fxgui/src/edu/kit/iti/algover/editor/DafnyCodeArea.java
@@ -134,8 +134,6 @@ public class DafnyCodeArea extends AsyncHighlightingCodeArea {
     }
 
     private void matchBracesInCurrentLine(int indent) {
-        // TODO: Make more readable.
-
         if (indent < 1) {
             return;
         }
@@ -143,12 +141,18 @@ public class DafnyCodeArea extends AsyncHighlightingCodeArea {
         if (!currentLine.endsWith("{")) {
             return;
         }
-        String trailingBraces = currentLine.substring(currentLine.indexOf('{'), currentLine.lastIndexOf('{') + 1);
+        Pattern pattern = Pattern.compile("[\\{]+");
+        Matcher matcher = pattern.matcher(currentLine);
+        String trailingBraces = "";
+        // find last occurrence
+        while (matcher.find()) {
+            trailingBraces = matcher.group();
+        }
         int bracesOpenedL = 0;
 
-        if (trailingBraces.length() > 0 && trailingBraces.chars().allMatch(ch -> ch == '{')) {
+        if (trailingBraces.length() > 0) {
             bracesOpenedL = trailingBraces.length();
-        } else { // should be never reached
+        } else {
             return;
         }
 
@@ -156,11 +160,11 @@ public class DafnyCodeArea extends AsyncHighlightingCodeArea {
 
         String follow = this.getText(this.getCaretPosition(), this.getText().length());
 
-        String search = " ".repeat(toIndent * tabWidth) + "}";
-        int idxClose = follow.indexOf(search);
+        String closingBraces = " ".repeat(toIndent * tabWidth) + "}";
+        int idxClose = follow.indexOf(closingBraces);
 
         if (idxClose != -1) {
-            follow = follow.substring(0, follow.indexOf(search));
+            follow = follow.substring(0, idxClose);
         }
 
         long openBraces = follow.chars().filter(ch -> ch == '{').count();
@@ -168,11 +172,10 @@ public class DafnyCodeArea extends AsyncHighlightingCodeArea {
 
         if (openBraces != closeBraces) {
             int pos = this.getCaretPosition();
-
             this.insertText(this.getCaretPosition(), "\n" +
                     " ".repeat(tabWidth * (toIndent)));
             this.insertText(this.getCaretPosition(), "}".repeat(bracesOpenedL));
-            moveTo(pos);
+            this.moveTo(pos);
         }
     }
 

--- a/modules/fxgui/src/edu/kit/iti/algover/timeline/MultiViewSplitPane.java
+++ b/modules/fxgui/src/edu/kit/iti/algover/timeline/MultiViewSplitPane.java
@@ -232,20 +232,22 @@ public class MultiViewSplitPane extends Pane {
         ObservableList<SplitPane.Divider> dividers = this.splitPane.getDividers();
         // Even indexed dividers are only linked upon frame change
         linkDividerPositions();
-        // if the even indexed dividers are reset
-        if (oldPos % 2 == 0) {
-            // A bit hacky: the value is required to change, for listener to be triggered
-            // Very hacky: not resetting it seems to prevent a repaint bug in FormulaCell.
-            // That is why it is shifted in different directions in each call.
-            dividers.get(oldPos).setPosition(dividers.get(oldPos).getPosition()
-                    +0.001 * alternateDividerShiftFactor);
-            alternateDividerShiftFactor *= (-1);
-        } else { // if the odd indexed, fixed dividers are reset
+
+        // if the odd indexed dividers are reset
+        if (oldPos % 2 == 1) {
             double desired = this.screenDividers[oldPos / 2];
             double delta = dividers.get(oldPos).getPosition() - desired;
             dividers.get(oldPos).setPosition(desired);
             dividers.get(newPos).setPosition(dividers.get(newPos).getPosition() - delta);
+
+            alternateDividerShiftFactor *= (-1);
         }
+
+        // A bit hacky: the divider position is required to change for ChangeListener to be triggered
+        // Very hacky: not resetting it seems to prevent JavaFX repaint bug for the individual nodes.
+        dividers.get(oldPos).setPosition(dividers.get(oldPos).getPosition()
+                +0.00051 * alternateDividerShiftFactor);
+
         unlinkDividerPositions();
     }
 


### PR DESCRIPTION
This introduces a rudimentary idea to match curly braces from the current line in the dafny file editor. It also fixes one issue. Closing too many braces used to trigger an exception on hitting enter.
This also fixes a JavaFX repaint bug which caused editor lines to become white on editing.

I think this already makes typing a little more comfortable, a more in-depth modelling of braces and parenthesis matching may be discussed.