### PR TITLE
Introduce sealable AST

### DIFF
--- a/modules/core/src/edu/kit/iti/algover/nuscript/Interpreter.java
+++ b/modules/core/src/edu/kit/iti/algover/nuscript/Interpreter.java
@@ -58,7 +58,7 @@ public final class Interpreter extends DefaultScriptASTVisitor<Void, Void, Scrip
     /** Used for debugging */
     private static final boolean VERBOSE = false;
 
-    /** The set of avaiable rules for this particular proof */
+    /** The set of available rules for this particular proof */
     private final Map<String, ProofRule> knownRules;
 
     /** The freshly created proof root */

--- a/modules/core/src/edu/kit/iti/algover/nuscript/ScriptAST.java
+++ b/modules/core/src/edu/kit/iti/algover/nuscript/ScriptAST.java
@@ -176,6 +176,7 @@ public abstract class ScriptAST {
          * @throws SealedException if the ast has been sealed.
          */
         public void addStatement(Statement stmt) {
+            // Valentin: Consider setting parent relationship here
             statements.add(stmt);
         }
 

--- a/modules/core/src/edu/kit/iti/algover/nuscript/UnsealedCopyVisitor.java
+++ b/modules/core/src/edu/kit/iti/algover/nuscript/UnsealedCopyVisitor.java
@@ -1,0 +1,79 @@
+package edu.kit.iti.algover.nuscript;
+
+import de.uka.ilkd.pp.NoExceptions;
+import edu.kit.iti.algover.nuscript.ScriptAST.ByClause;
+import edu.kit.iti.algover.nuscript.ScriptAST.Case;
+import edu.kit.iti.algover.nuscript.ScriptAST.Cases;
+import edu.kit.iti.algover.nuscript.ScriptAST.Command;
+import edu.kit.iti.algover.nuscript.ScriptAST.Parameter;
+import edu.kit.iti.algover.nuscript.ScriptAST.Script;
+import edu.kit.iti.algover.nuscript.ScriptAST.Statement;
+
+public class UnsealedCopyVisitor extends DefaultScriptASTVisitor<ScriptAST, ScriptAST, NoExceptions> {
+
+    public static final UnsealedCopyVisitor INSTANCE = new UnsealedCopyVisitor();
+
+    @Override
+    public Script visitScript(Script script, ScriptAST arg) throws NoExceptions {
+        Script ret = new Script();
+        for (Statement statement : script.getStatements()) {
+            ret.addStatement((Statement)statement.accept(this, arg));
+        }
+        ret.setParent(arg);
+        return ret;
+    }
+
+    @Override
+    public Parameter visitParameter(Parameter parameter, ScriptAST arg) throws NoExceptions {
+        Parameter ret = new Parameter();
+        ret.setName(parameter.getName());
+        ret.setValue(parameter.getValue());
+        ret.setParent(arg);
+        return ret;
+    }
+
+    @Override
+    public ScriptAST visitCommand(Command command, ScriptAST arg) throws NoExceptions {
+        Command ret = new Command();
+        ret.setCommand(command.getCommand());
+        ret.setByClause(visitByClause(command.getByClause(), ret));
+        ret.setProofNode(command.getProofNode());
+        for (Parameter parameter : command.getParameters()) {
+            ret.addParameter(visitParameter(parameter, ret));
+        }
+        ret.setParent(arg);
+        return ret;
+    }
+
+    @Override
+    public ByClause visitByClause(ByClause byClause, ScriptAST arg) throws NoExceptions {
+        ByClause ret = new ByClause();
+        ret.setOpeningBrace(byClause.getOpeningBrace());
+        for (Statement statement : byClause.getStatements()) {
+            ret.addStatement((Statement)statement.accept(this, ret));
+        }
+        ret.setParent(arg);
+        return ret;
+    }
+
+    @Override
+    public Case visitCase(Case aCase, ScriptAST arg) throws NoExceptions {
+        Case ret = new Case();
+        aCase.setLabel(aCase.getLabel());
+        for (Statement statement : aCase.getStatements()) {
+            ret.addStatement((Statement)statement.accept(this, ret));
+        }
+        ret.setProofNode(aCase.getProofNode());
+        ret.setParent(arg);
+        return ret;
+    }
+
+    @Override
+    public Cases visitCases(Cases cases, ScriptAST arg) throws NoExceptions {
+        Cases ret = new Cases();
+        for (Case aCase : cases.getCases()) {
+            ret.addCase(visitCase(aCase, ret));
+        }
+        return ret;
+    }
+}

--- a/modules/core/src/edu/kit/iti/algover/nuscript/UnsealedCopyVisitor.java
+++ b/modules/core/src/edu/kit/iti/algover/nuscript/UnsealedCopyVisitor.java
@@ -13,11 +13,12 @@ public class UnsealedCopyVisitor extends DefaultScriptASTVisitor<ScriptAST, Scri
 
     public static final UnsealedCopyVisitor INSTANCE = new UnsealedCopyVisitor();
 
+
     @Override
     public Script visitScript(Script script, ScriptAST arg) throws NoExceptions {
         Script ret = new Script();
         for (Statement statement : script.getStatements()) {
-            ret.addStatement((Statement)statement.accept(this, arg));
+            ret.addStatement((Statement)statement.accept(this, ret));
         }
         ret.setParent(arg);
         return ret;
@@ -47,6 +48,9 @@ public class UnsealedCopyVisitor extends DefaultScriptASTVisitor<ScriptAST, Scri
 
     @Override
     public ByClause visitByClause(ByClause byClause, ScriptAST arg) throws NoExceptions {
+        if (byClause == null) {
+            return null;
+        }
         ByClause ret = new ByClause();
         ret.setOpeningBrace(byClause.getOpeningBrace());
         for (Statement statement : byClause.getStatements()) {
@@ -59,7 +63,7 @@ public class UnsealedCopyVisitor extends DefaultScriptASTVisitor<ScriptAST, Scri
     @Override
     public Case visitCase(Case aCase, ScriptAST arg) throws NoExceptions {
         Case ret = new Case();
-        aCase.setLabel(aCase.getLabel());
+        ret.setLabel(aCase.getLabel());
         for (Statement statement : aCase.getStatements()) {
             ret.addStatement((Statement)statement.accept(this, ret));
         }
@@ -74,6 +78,7 @@ public class UnsealedCopyVisitor extends DefaultScriptASTVisitor<ScriptAST, Scri
         for (Case aCase : cases.getCases()) {
             ret.addCase(visitCase(aCase, ret));
         }
+        ret.setParent(arg);
         return ret;
     }
 }

--- a/modules/core/src/edu/kit/iti/algover/proof/Proof.java
+++ b/modules/core/src/edu/kit/iti/algover/proof/Proof.java
@@ -13,6 +13,7 @@ import edu.kit.iti.algover.project.Project;
 import edu.kit.iti.algover.references.ReferenceGraph;
 import edu.kit.iti.algover.rules.RuleException;
 import edu.kit.iti.algover.util.ObservableValue;
+import edu.kit.iti.algover.util.ObservableValue.ChangeListener;
 import edu.kit.iti.algover.util.ProofTreeUtil;
 import nonnull.NonNull;
 import nonnull.Nullable;
@@ -55,15 +56,15 @@ public class Proof {
     /**
      * The script text.
      *
-     * mutable, should never be null.
-     * If a proofRoot is present, it results from this very script object.
+     * mutable, can be null if scriptAST has been set directly.
      */
-    private @NonNull String script = "";
+    private @Nullable String scriptText;
 
     /**
      * The AST of the script.
      *
-     * mutable, can be null if not yet parsed (in the beginning or after setting a script)
+     * mutable, can be null if not yet parsed
+     * (in the beginning or after setting a script)
      */
     private @Nullable Script scriptAST;
 
@@ -138,12 +139,7 @@ public class Proof {
     }
 
     public @Nullable String getScriptText() {
-        return script;
-    }
-
-
-    public @NonNull ObservableValue<ProofStatus> proofStatusObservableValue() {
-        return this.proofStatus;
+        return scriptText;
     }
 
     /**
@@ -163,6 +159,10 @@ public class Proof {
         proofStatus.addObserver(listener);
     }
 
+    public void removeProofStatusListener(ChangeListener<ProofStatus> listener) {
+        proofStatus.removeObserver(listener);
+    }
+
     /**
      * Add all code references from a Dafny file to the refrence graph.
      *
@@ -173,41 +173,44 @@ public class Proof {
     }
 
     /**
-     * Parses a script as string representation and sets the parsed AST to null.
+     * Sets a script string representation and sets the parsed AST to null.
      * Set the state to {@link ProofStatus#CHANGED_SCRIPT}.
      *
      * @param script string representation of script
      */
     public void setScriptText(@NonNull String script) {
-        if (this.getScriptText() != null) {
-            saveOldDataStructures();
-        }
-
-        this.script = script;
-        try {
-            this.scriptAST = Scripts.parseScript(script);
-        } catch (Exception ex) {
-            this.failures = Collections.singletonList(ex);
-            this.scriptAST = null;
-            proofStatus.setValue(ProofStatus.FAILING);
-        }
-
+        this.scriptText = script;
+        this.scriptAST = null;
         this.proofStatus.setValue(ProofStatus.CHANGED_SCRIPT);
     }
 
-    public void setScriptAST (Script script) {
+    /**
+     * Sets a script string representation and sets the script text to null.
+     * Set the state to {@link ProofStatus#CHANGED_SCRIPT}.
+     *
+     * @param script string representation of script
+     */
+    public void setScriptAST (@NonNull Script script) {
         this.scriptAST = script;
+        this.scriptText = null;
         this.proofStatus.setValue(ProofStatus.CHANGED_SCRIPT);
     }
 
     /**
      * Interpret Script. A script must have been set previously.
      *
-     * This will also parse the previously set script text. After this
-     * {@link #getProofScript()} will return a valid script, if parsing is successful.
+     * Requires that the proof state is {@link ProofStatus#CHANGED_SCRIPT}.
+     *
+     * This will also parse the previously set script text (if set via {@link
+     * #setScriptText(String)}). No parsing is involved if the script has been
+     * set with {@link #setScriptAST(Script)}.
+     *
+     * Afterwards, {@link #getProofScript()} will return a valid script, if
+     * parsing is successful.
      */
     public void interpretScript() {
-        assert script != null;
+
+        assert proofStatus.getValue() == ProofStatus.CHANGED_SCRIPT;
 
         Interpreter interpreter = new Interpreter(this);
 
@@ -216,8 +219,9 @@ public class Proof {
         this.proofRoot = interpreter.getRootNode();
 
         if (this.scriptAST == null) {
+            assert scriptText != null : "Either ast or text must not be null";
             try {
-                this.scriptAST = Scripts.parseScript(script);
+                this.scriptAST = Scripts.parseScript(scriptText);
             } catch (Exception ex) {
                 this.failures = Collections.singletonList(ex);
                 this.scriptAST = null;
@@ -241,8 +245,9 @@ public class Proof {
                 proofStatus.setValue(newRoot.allLeavesClosed() ?
                         ProofStatus.CLOSED : ProofStatus.OPEN);
             }
+            scriptAST.seal();
         } catch(Exception ex) {
-            System.err.println("This is an unexpected error (should not be raised):");
+            System.err.println("This is an unexpected error (that should never be raised):");
             ex.printStackTrace();
             this.failures = Collections.singletonList(ex);
             proofStatus.setValue(ProofStatus.FAILING);
@@ -314,12 +319,5 @@ public class Proof {
             sb.append("<null> proof");
         }
         return sb.toString();
-    }
-
-    /**
-     * Save the old script and the old proof for comparison when reloading
-     */
-    private void saveOldDataStructures() {
-        // future ...
     }
 }

--- a/modules/core/src/edu/kit/iti/algover/proof/ProofNode.java
+++ b/modules/core/src/edu/kit/iti/algover/proof/ProofNode.java
@@ -39,14 +39,12 @@ public class ProofNode {
 
     /**
      * Pointer to command that produced this node.
-     * Null if root
-     *
-     * Can be set after construction.
+     * null if root.
      */
     private final @Nullable Command command;
 
     /**
-     * Pointer to children; mutable
+     * Pointer to children; mutable list
      */
     private @Nullable List<ProofNode> children;
 

--- a/modules/core/src/edu/kit/iti/algover/proof/ProofStatus.java
+++ b/modules/core/src/edu/kit/iti/algover/proof/ProofStatus.java
@@ -25,7 +25,7 @@ public enum ProofStatus {
     /** Initial state. The proof's root is null.*/
     NON_EXISTING,
 
-    /** script has changed but has not been interpreted yet. */
+    /** script text or ast has changed but has not been interpreted yet. */
     CHANGED_SCRIPT,
 
     /** script has been run on proof, there remain unclosed branches */

--- a/modules/core/src/edu/kit/iti/algover/util/ObservableValue.java
+++ b/modules/core/src/edu/kit/iti/algover/util/ObservableValue.java
@@ -5,33 +5,86 @@
  */
 package edu.kit.iti.algover.util;
 
+import nonnull.NonNull;
+import nonnull.Nullable;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 
+/**
+ * A helper class which implements the observer pattern for a single value.
+ * Similar to properties in JavaFX, but way more lightweight.
+ *
+ * Every property has a name and actively knows about its type.
+ *
+ * Observers are implementations of the functional interface
+ * {@link ChangeListener}.
+ *
+ * @param <T> The type of the value to stored in the property.
+ *
+ * @author Mattias Ulbrich
+ */
 public class ObservableValue<T> {
 
+    /**
+     * A change listener is invoked whenever a value changes.
+     */
     @FunctionalInterface
     public interface ChangeListener<T> {
-        void changed(ObservableValue<T> observableValue, T oldValue, T newValue);
+        /**
+         * Invoked when the value of {@code observableValue} changes from {@code oldValue}
+         * to {@code newValue}.
+         *
+         * @param observableValue the observable item that has changed value
+         * @param oldValue the old value before changing
+         * @param newValue the new value after changing.
+         */
+        void changed(@NonNull ObservableValue<T> observableValue, @Nullable T oldValue, @Nullable T newValue);
     }
 
+    /** The name of this observable value (mainly for debugging) */
     private final String name;
+
+    /** The type of the value of this observable */
     private final Class<T> type;
 
+    /** The actual value currently stored in the observable */
     private T value;
+
+    /** The list of listeners to be notified when changes arrive */
     private List<ChangeListener<T>> observers;
 
+    /** A lock needed for synchronisation when used with several threads */
     private final Object listLock = new Object();
 
+    /**
+     * Some use cases may choose to store the origin of the change.
+     * Can be retrieved using {@link #getOrigin()}.
+     */
     private Object origin;
 
-    public ObservableValue(String name, Class<T> type, T initialValue) {
+    /**
+     * Create a new observable value object.
+     *
+     * @param name name of the observable
+     * @param type the class that can be stored in the value
+     * @param initialValue the initial value.
+     */
+    public ObservableValue(@NonNull  String name, @NonNull  Class<T> type, @Nullable T initialValue) {
         this.name = name;
         this.type = type;
         this.value = initialValue;
     }
 
+    /**
+     * Create a new observable value object.
+     *
+     * Initial value is null.
+     *
+     * @param name name of the observable
+     * @param type the class that can be stored in the value
+     */
     public ObservableValue(String name, Class<T> type) {
         this(name, type, null);
     }
@@ -72,14 +125,12 @@ public class ObservableValue<T> {
     }
 
     public void addObserver(ChangeListener<T> observer) {
-        if(observers == null) {
-            synchronized (listLock) {
-                if(observers == null) {
-                    observers = new LinkedList<ChangeListener<T>>();
-                }
+        synchronized (listLock) {
+            if (observers == null) {
+                observers = new LinkedList<>();
             }
+            observers.add(observer);
         }
-        observers.add(observer);
     }
 
     public void removeObserver(ChangeListener<T> observer) {

--- a/modules/core/src/edu/kit/iti/algover/util/ScriptASTUtil.java
+++ b/modules/core/src/edu/kit/iti/algover/util/ScriptASTUtil.java
@@ -17,7 +17,6 @@ import java.util.logging.Logger;
 /**
  * Utility class for Creating new ScriptASTs. Used for inserting a new Statement
  * into a given ScriptAST.Script
- * Could and probabily will be extended to insert any statement after a given statement.
  *
  * @author Valentin Springsklee
  *
@@ -28,8 +27,10 @@ public class ScriptASTUtil {
         throw new Error();
     }
 
-
     public static Script insertStatementAfter(Script script, Statement newStatement, ScriptAST referenceASTElem) {
+        // Maybe implement InsertAfterStatementVisitor class, extends
+        // DefaultScriptASTVisitor<Triple<Statement, ScriptAST, ScriptAST>, ScriptAST, SomeException>
+        // pass new Triple<>(newStatement, referenceStatememnt, parentAST) a arg
         ScriptAST updated = script.accept(new UnsealedCopyVisitor() {
 
             protected void visitStatements(ScriptAST.StatementList old,
@@ -132,7 +133,7 @@ public class ScriptASTUtil {
         for(ProofNode p : pn.getChildren()) {
             boolean found = false;
             for(ScriptAST.Case caze : cases) {
-                //apparently some guards are string literals and some are MathcExpressions...
+                // apparently some guards are string literals and some are MathcExpressions...
                 String caseString = Util.stripQuotes(caze.getLabel().getText());
                 if (caseString.equals(p.getLabel())) {
                     List<ScriptAST.Statement> statements = insertCasesForStatement(p, caze.getStatements());

--- a/modules/core/src/edu/kit/iti/algover/util/ScriptASTUtil.java
+++ b/modules/core/src/edu/kit/iti/algover/util/ScriptASTUtil.java
@@ -1,13 +1,10 @@
 package edu.kit.iti.algover.util;
 
-import edu.kit.iti.algover.nuscript.DefaultScriptASTVisitor;
-import edu.kit.iti.algover.nuscript.ParentRelationVisitor;
-import edu.kit.iti.algover.nuscript.ScriptAST;
+import de.uka.ilkd.pp.NoExceptions;
+import edu.kit.iti.algover.nuscript.*;
 import edu.kit.iti.algover.nuscript.ScriptAST.Script;
 import edu.kit.iti.algover.nuscript.ScriptAST.Statement;
-import edu.kit.iti.algover.nuscript.ScriptAST.Cases;
 import edu.kit.iti.algover.nuscript.ScriptAST.Case;
-import edu.kit.iti.algover.nuscript.ScriptAST.Command;
 import edu.kit.iti.algover.nuscript.parser.ScriptParser;
 import edu.kit.iti.algover.proof.ProofNode;
 
@@ -31,54 +28,55 @@ public class ScriptASTUtil {
         throw new Error();
     }
 
-    public static Script createScriptWithStatements(List<Statement> statements) {
-        Script script = new Script();
-        script.getStatements().addAll(statements);
-        ParentRelationVisitor.setParentRelation(script);
-        return script;
-    }
 
+    public static Script insertStatementAfter(Script script, Statement newStatement, ScriptAST referenceASTElem) {
+        ScriptAST updated = script.accept(new UnsealedCopyVisitor() {
 
-    public static Case createEmptyCaseFrom(Case oldCase) {
-        Case newCase = new Case();
-        newCase.setLabel(oldCase.getLabel());
-        newCase.setProofNode(oldCase.getProofNode());
-
-        return newCase;
-    }
-
-
-    public static Script insertIntoCase(Script script, Statement newStatement, Case target) {
-        Script updatedScript = new Script();
-
-        for (Statement stmt: script.getStatements()) {
-            updatedScript.addStatement(stmt.accept(new DefaultScriptASTVisitor<Void, Statement, RuntimeException>() {
-                @Override
-                public Command visitCommand(Command command, Void arg) throws RuntimeException {
-                    return command;
-                }
-
-                @Override
-                public Cases visitCases(Cases cases, Void arg) throws RuntimeException {
-                    Cases newCases = new Cases();
-                    for (Case c: cases.getCases()) {
-                        Case newCase = createEmptyCaseFrom(c);
-                        for (Statement stmtC: c.getStatements()) {
-                            newCase.addStatement(stmtC.accept(this, null));
-                        }
-                        if (c == target) {
-                            newCase.addStatement(newStatement);
-                        }
-                        newCases.addCase(newCase);
+            protected void visitStatements(ScriptAST.StatementList old,
+                                           ScriptAST.StatementList newList,
+                                           Statement newStatement,
+                                           ScriptAST referenceASTElem) {
+                for (Statement statement : old.getStatements()) {
+                    if (statement == referenceASTElem) {
+                        newList.addStatement(newStatement);
+                        newStatement.setParent(newList);
                     }
-                    return newCases;
+                    newList.addStatement((Statement) statement.accept(this, newList));
                 }
-            }, null));
-        }
 
-        ParentRelationVisitor.setParentRelation(updatedScript);
+                if (old == referenceASTElem) {
+                    newList.addStatement(newStatement);
+                    newStatement.setParent(newList);
+                }
+            }
 
-        return updatedScript;
+            @Override
+            public Script visitScript(Script script, ScriptAST arg) throws NoExceptions {
+                Script ret = new Script();
+                visitStatements(script, ret, newStatement, referenceASTElem);
+                ret.setParent(arg);
+
+                return ret;
+            }
+
+            @Override
+            public Case visitCase(Case aCase, ScriptAST arg) throws NoExceptions {
+                Case ret = new Case();
+                ret.setLabel(aCase.getLabel());
+
+                visitStatements(aCase, ret, newStatement, referenceASTElem);
+
+                ret.setProofNode(aCase.getProofNode());
+                ret.setParent(arg);
+
+                return ret;
+            }
+
+
+        }, null);
+
+
+        return (Script) updated;
     }
 
     /**
@@ -154,67 +152,5 @@ public class ScriptASTUtil {
 
     private static ScriptAST.Statement createCasesForNode(ProofNode pn) {
         return createCasesForNode(pn, new ArrayList<>());
-    }
-
-    public static List<Statement> insertStatementAfter(List<Statement>  statements, Statement newStatement, ScriptAST referenceStatement) {
-        for(int i = 0; i < statements.size(); ++i) {
-            if(statements.get(i) == referenceStatement) {
-                statements.add(i + 1, newStatement);
-                return statements;
-            }
-            if(statements.get(i) instanceof Cases) {
-                for(int j = 0; j < ((Cases) statements.get(i)).getCases().size(); ++j) {
-                    List<Statement> res = insertStatementAfter(((Cases) statements.get(i)).getCases().get(j).getStatements(), newStatement, referenceStatement);
-                    if(res != null) {
-                        return res;
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
-    public static Script insertStatementAfter(Script script, Statement newStatement, Statement referenceStatement) {
-        List<Statement> res = insertStatementAfter(script.getStatements(), newStatement, referenceStatement);
-        if(res == null) {
-            System.out.println("Couldnt find reference statement to insert new statement.");
-        }
-        return script;
-
-    }
-
-    public static Script insertStatementAfter(Script script, Statement newStatement, Case referenceStatement) {
-        List<Statement> res = insertStatementAfter(script.getStatements(), newStatement, referenceStatement);
-        if (res == null) {
-            System.out.println("Couldnt find reference statement to insert new statement.");
-        }
-        return script;
-    }
-
-    public static List<Statement> insertStatementAfter(List<Statement> statements, Statement newStatement, Case referenceStatement) {
-        for(int i = 0; i < statements.size(); ++i) {
-            if(statements.get(i) instanceof Cases) {
-                for(int j = 0; j < ((Cases) statements.get(i)).getCases().size(); ++j) {
-                    if(((Cases) statements.get(i)).getCases().get(j) == referenceStatement) {
-                        ((Cases) statements.get(i)).getCases().get(j).getStatements().add(newStatement);
-                        return statements;
-                    }
-                    List<Statement> res = insertStatementAfter(((Cases) statements.get(i)).getCases().get(j).getStatements(), newStatement, referenceStatement);
-                    if(res != null) {
-                        return res;
-                    }
-                }
-            }
-        }
-        return null;
-    }
-
-    public static Script insertStatementAfter(Script script, Statement newStatement, ScriptAST referenceStatement) {
-        if(referenceStatement instanceof Statement) {
-            return insertStatementAfter(script, newStatement, (Statement) referenceStatement);
-        } else if (referenceStatement instanceof Case) {
-            return insertStatementAfter(script, newStatement, (Case) referenceStatement);
-        }
-        return null;
     }
 }

--- a/modules/core/src/edu/kit/iti/algover/util/sealable/Sealable.java
+++ b/modules/core/src/edu/kit/iti/algover/util/sealable/Sealable.java
@@ -1,0 +1,28 @@
+package edu.kit.iti.algover.util.sealable;
+
+import java.util.function.Supplier;
+
+public final class Sealable<T> {
+
+    private T value;
+    private final Supplier<Boolean> sealCheck;
+
+    public Sealable(Supplier<Boolean> sealCheck) {
+        this.sealCheck = sealCheck;
+    }
+
+    public T get() {
+        return value;
+    }
+
+    public void set(T value) {
+        if(sealCheck.get()) {
+            throw new SealedException();
+        }
+        this.value = value;
+    }
+
+    public boolean isSet() {
+        return value != null;
+    }
+}

--- a/modules/core/src/edu/kit/iti/algover/util/sealable/SealableList.java
+++ b/modules/core/src/edu/kit/iti/algover/util/sealable/SealableList.java
@@ -1,0 +1,47 @@
+package edu.kit.iti.algover.util.sealable;
+
+import java.util.AbstractList;
+import java.util.List;
+import java.util.function.Supplier;
+
+public class SealableList<T> extends AbstractList<T> {
+
+    private final Supplier<Boolean> sealCheck;
+    private final List<T> delegate;
+
+    public SealableList(Supplier<Boolean> sealCheck, List<T> delegate) {
+        this.sealCheck = sealCheck;
+        this.delegate = delegate;
+    }
+
+    @Override
+    public T get(int index) {
+        return delegate.get(index);
+    }
+
+    @Override
+    public int size() {
+        return delegate.size();
+    }
+
+    public void add(int index, T element) {
+        if(sealCheck.get()) {
+            throw new SealedException();
+        }
+        delegate.add(index, element);
+    }
+
+    public T remove(int index) {
+        if(sealCheck.get()) {
+            throw new SealedException();
+        }
+        return delegate.remove(index);
+    }
+
+    public T set(int index, T element) {
+        if (sealCheck.get()) {
+            throw new SealedException();
+        }
+        return delegate.set(index, element);
+    }
+}

--- a/modules/core/src/edu/kit/iti/algover/util/sealable/SealedException.java
+++ b/modules/core/src/edu/kit/iti/algover/util/sealable/SealedException.java
@@ -1,0 +1,22 @@
+package edu.kit.iti.algover.util.sealable;
+
+public class SealedException extends RuntimeException {
+    public SealedException() {
+    }
+
+    public SealedException(String message) {
+        super(message);
+    }
+
+    public SealedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SealedException(Throwable cause) {
+        super(cause);
+    }
+
+    public SealedException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}

--- a/modules/core/test/edu/kit/iti/algover/nuscript/ParentRelationVisitorTest.java
+++ b/modules/core/test/edu/kit/iti/algover/nuscript/ParentRelationVisitorTest.java
@@ -22,9 +22,10 @@ public class ParentRelationVisitorTest {
     public void testParentRelation() throws Exception {
         Script script = Scripts.parseScript(testScript);
         ParentRelationVisitor.setParentRelation(script);
+        script.accept(new ParentCheck(), null);
     }
 
-    private class ParentCheck implements ScriptASTVisitor<ScriptAST, Void, RuntimeException> {
+    private static class ParentCheck implements ScriptASTVisitor<ScriptAST, Void, RuntimeException> {
 
         @Override
         public Void visitScript(Script script, ScriptAST arg) throws RuntimeException {
@@ -41,7 +42,7 @@ public class ParentRelationVisitorTest {
             for (Parameter parameter : command.getParameters()) {
                 parameter.accept(this, command);
             }
-            if(command.getCommand() != null) {
+            if(command.getByClause() != null) {
                 command.getByClause().accept(this, command);
             }
             return null;

--- a/modules/core/test/edu/kit/iti/algover/nuscript/ParentRelationVisitorTest.java
+++ b/modules/core/test/edu/kit/iti/algover/nuscript/ParentRelationVisitorTest.java
@@ -1,0 +1,81 @@
+package edu.kit.iti.algover.nuscript;
+
+import edu.kit.iti.algover.nuscript.ScriptAST.ByClause;
+import edu.kit.iti.algover.nuscript.ScriptAST.Case;
+import edu.kit.iti.algover.nuscript.ScriptAST.Cases;
+import edu.kit.iti.algover.nuscript.ScriptAST.Command;
+import edu.kit.iti.algover.nuscript.ScriptAST.Parameter;
+import edu.kit.iti.algover.nuscript.ScriptAST.Script;
+import edu.kit.iti.algover.nuscript.ScriptAST.Statement;
+import edu.kit.iti.algover.nuscript.parser.Scripts;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ParentRelationVisitorTest {
+
+    private static final String testScript = "cmd by { c1; c2; } cmd;" +
+            " cases { \"case 1\": cmd; cmd by otherCmd; \"case 2\": skip; \"opencase\": }";
+
+    @Test
+    public void testParentRelation() throws Exception {
+        Script script = Scripts.parseScript(testScript);
+        ParentRelationVisitor.setParentRelation(script);
+    }
+
+    private class ParentCheck implements ScriptASTVisitor<ScriptAST, Void, RuntimeException> {
+
+        @Override
+        public Void visitScript(Script script, ScriptAST arg) throws RuntimeException {
+            assertNull(script.getParent());
+            for (Statement statement : script.getStatements()) {
+                statement.accept(this, script);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitCommand(Command command, ScriptAST arg) throws RuntimeException {
+            assertEquals(arg, command.getParent());
+            for (Parameter parameter : command.getParameters()) {
+                parameter.accept(this, command);
+            }
+            if(command.getCommand() != null) {
+                command.getByClause().accept(this, command);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitParameter(Parameter parameter, ScriptAST arg) throws RuntimeException {
+            assertEquals(arg, parameter.getParent());
+            return null;
+        }
+
+        @Override
+        public Void visitCases(Cases cases, ScriptAST arg) throws RuntimeException {
+            assertEquals(arg, cases.getParent());
+            for (Case aCase : cases.getCases()) {
+                aCase.accept(this, cases);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitCase(Case aCase, ScriptAST arg) throws RuntimeException {
+            assertEquals(arg, aCase.getParent());
+            for (Statement statement : aCase.getStatements()) {
+                statement.accept(this, aCase);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitByClause(ByClause byClause, ScriptAST arg) throws RuntimeException {
+            assertEquals(arg, byClause.getParent());
+            return null;
+        }
+    }
+
+}

--- a/modules/core/test/edu/kit/iti/algover/nuscript/ScriptASTTest.java
+++ b/modules/core/test/edu/kit/iti/algover/nuscript/ScriptASTTest.java
@@ -1,0 +1,76 @@
+package edu.kit.iti.algover.nuscript;
+
+import de.uka.ilkd.pp.NoExceptions;
+import edu.kit.iti.algover.nuscript.ScriptAST.ByClause;
+import edu.kit.iti.algover.nuscript.ScriptAST.Case;
+import edu.kit.iti.algover.nuscript.ScriptAST.Cases;
+import edu.kit.iti.algover.nuscript.ScriptAST.Command;
+import edu.kit.iti.algover.nuscript.ScriptAST.Script;
+import edu.kit.iti.algover.nuscript.ScriptAST.Statement;
+import edu.kit.iti.algover.nuscript.parser.ScriptParser;
+import edu.kit.iti.algover.nuscript.parser.ScriptParser.ScriptContext;
+import edu.kit.iti.algover.nuscript.parser.Scripts;
+import edu.kit.iti.algover.script.ScriptParserTest;
+import edu.kit.iti.algover.util.sealable.SealedException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ScriptASTTest {
+
+    private Script script;
+
+    @Before
+    public void makeScript() {
+        this.script = Scripts.parseScript("command1 param1='term1' param2=22 by { command2; }\n" +
+                "cmd3; cases { case \"A\": skip; }");
+    }
+
+    @Test
+    public void testSealed() throws Exception {
+        assertFalse(script.isSealed());
+        script.seal();
+        assertTrue(script.isSealed());
+        for (Statement statement : script.getStatements()) {
+            assertTrue(statement.isSealed());
+        }
+        Command cmd = (Command)script.getStatements().get(0);
+        assertTrue(cmd.isSealed());
+        ByClause bc = cmd.getByClause();
+        assertTrue(bc.isSealed());
+        assertTrue(bc.getStatements().get(0).isSealed());
+        Cases cases = (Cases) script.getStatements().get(2);
+        assertTrue(cases.isSealed());
+        Case aCase = cases.getCases().get(0);
+        assertTrue(aCase.isSealed());
+        assertTrue(aCase.getStatements().get(0).isSealed());
+    }
+
+    @Test
+    public void testSealViolation() throws Exception {
+
+        script.seal();
+
+        shouldFail(() -> script.setParent(null));
+        shouldFail(() -> script.addStatement(null));
+        shouldFail(() -> script.getStatements().add(null));
+        shouldFail(() -> script.setRangeFrom(new ScriptContext(null, 0)));
+        Command cmd = (Command)script.getStatements().get(0);
+        shouldFail(() -> cmd.setProofNode(null));
+        shouldFail(() -> cmd.setByClause(null));
+        shouldFail(() -> cmd.addParameter(null));
+        shouldFail(() -> cmd.getParameters().add(null));
+    }
+
+    private void shouldFail(Runnable run) {
+        try {
+            run.run();
+            fail("Should have failed with a SealedException");
+        } catch (SealedException ex) {
+            // ok, continue
+        }
+    }
+}

--- a/modules/fxgui/src/edu/kit/iti/algover/MainController.java
+++ b/modules/fxgui/src/edu/kit/iti/algover/MainController.java
@@ -644,7 +644,6 @@ public class MainController implements RuleApplicationListener {
 
         PropertyManager.getInstance().currentProof.get().interpretScript();
 
-        PropertyManager.getInstance().currentProofStatus.set(PropertyManager.getInstance().currentProof.get().getProofStatus());
         ruleApplicationController.resetConsideration();
         if(PropertyManager.getInstance().currentProofStatus.get() != ProofStatus.FAILING) {
             sequentController.getActiveSequentController().tryMovingOnEx(); //SaG: was tryMovingOn()

--- a/modules/fxgui/src/edu/kit/iti/algover/PropertyManager.java
+++ b/modules/fxgui/src/edu/kit/iti/algover/PropertyManager.java
@@ -158,10 +158,10 @@ public class PropertyManager {
         // TODO: review Proof and maybe use beans/fx properties.
         currentProof.addListener(((observable, oldValue, newValue) -> {
             if (oldValue != null) {
-                oldValue.proofStatusObservableValue().removeObserver(proofStatusSyncer);
+                oldValue.removeProofStatusListener(proofStatusSyncer);
             }
             if (newValue != null) {
-                newValue.proofStatusObservableValue().addObserver(proofStatusSyncer);
+                newValue.addProofStatusListener(proofStatusSyncer);
                 newValue.interpretScript();
             }
         }));

--- a/modules/fxgui/src/edu/kit/iti/algover/rule/RuleApplicationController.java
+++ b/modules/fxgui/src/edu/kit/iti/algover/rule/RuleApplicationController.java
@@ -150,7 +150,6 @@ public class RuleApplicationController extends FxmlController implements Referen
         ruleGrid.getSelectionModel().selectedItemProperty().addListener(this::onSelectedItemChanged);
 
         btInsertCases.setOnAction(event -> {
-            System.out.println("trying to insert cases");
             scriptRepWeb.onInsertCases();
         });
 
@@ -227,6 +226,8 @@ public class RuleApplicationController extends FxmlController implements Referen
             resetConsideration();
             // TODO: create new Statement directly from ProofRuleApplication.
             ScriptAST.Script newLine = Scripts.parseScript(application.getScriptTranscript());
+
+
 
             scriptRepWeb.insertAtCurrentPosition(application, newLine);
 

--- a/modules/fxgui/src/edu/kit/iti/algover/rule/script/BlocklyController.java
+++ b/modules/fxgui/src/edu/kit/iti/algover/rule/script/BlocklyController.java
@@ -143,7 +143,7 @@ public class BlocklyController implements ScriptViewListener {
         if (script == null) {
             return;
         }
-        ProofNode pn = script.accept(new ProofNodeExtractionVisitor(), null);
+        ProofNode pn = script.accept(ProofNodeExtractionVisitor.INSTANCE, null);
         if (pn != null) {
             if (pn.isClosed()) {
                 view.setClosedProofEnd(script);
@@ -160,7 +160,7 @@ public class BlocklyController implements ScriptViewListener {
                     System.out.println("Case" + aCase.getLabel().toString());
                     scanProofEnds(aCase);
                 }
-                ProofNode splitting = cases.accept(new ProofNodeExtractionVisitor(), null).getParent();
+                ProofNode splitting = cases.accept(ProofNodeExtractionVisitor.INSTANCE, null).getParent();
                 System.out.println("parent pn has " + splitting.getChildren().size() + " children.");
                 if (splitting.getChildren().size() > cases.getCases().size()) {
                     caseOpen = true;
@@ -182,19 +182,22 @@ public class BlocklyController implements ScriptViewListener {
 
     /**
      * Insert AST to position of display
-     * @param
-     * @return
+     * @param app
+     * @param ruleScript parsed app
+     * Parameters redundant
      */
     public void insertAtCurrentPosition(ProofRuleApplication app, ScriptAST.Script ruleScript) {
         // introduced for readabilty
-        ProofNode selectedPN = PropertyManager.getInstance().currentProofNode.get();
         Script currentProofScript = PropertyManager.getInstance().currentProof.get().getProofScript();
 
         if (highlightedStatement.get() == null) {
             return;
         }
 
-        Script updatedScript = ScriptASTUtil.insertStatementAfter(currentProofScript, ruleScript.getStatements().get(0),
+        // TODO: create from ProofRuleApplication, also look at RuleApplicationController for that.
+        ScriptAST.Statement newStatement = ruleScript.getStatements().get(0);
+
+        Script updatedScript = ScriptASTUtil.insertStatementAfter(currentProofScript, newStatement,
                highlightedStatement.getValue());
 
         PropertyManager.getInstance().currentProof.get().setScriptAST(updatedScript);
@@ -242,7 +245,7 @@ public class BlocklyController implements ScriptViewListener {
     @Override
     public void onASTElemSelected(ScriptAST astElem) {
         highlightedStatement.set(astElem);
-        ProofNode displayNode = astElem.accept(new ProofNodeExtractionVisitor(), null);
+        ProofNode displayNode = astElem.accept(ProofNodeExtractionVisitor.INSTANCE, null);
         PropertyManager.getInstance().currentProofNode.set(displayNode);
     }
 

--- a/modules/fxgui/src/edu/kit/iti/algover/rule/script/ProofNodeExtractionVisitor.java
+++ b/modules/fxgui/src/edu/kit/iti/algover/rule/script/ProofNodeExtractionVisitor.java
@@ -16,6 +16,8 @@ import java.util.List;
  */
 public class ProofNodeExtractionVisitor extends DefaultScriptASTVisitor<Void, ProofNode, IllegalArgumentException> {
 
+    public static final ProofNodeExtractionVisitor INSTANCE = new ProofNodeExtractionVisitor();
+
     /**
      * TODO: add documentation
      * @param statementList


### PR DESCRIPTION
As discussed, ScriptASTs can be sealed. They are in particular sealed after interpretation.

ProofNodes have not been modified to carry the exceptions.

Instead the existing Proof.getFailures can be used to obtain all relevant exceptions.
Those exceptions which belong to a proof node are of type ScriptException and carry a pointer to the command that caused them. That can be used.