### PR TITLE
fixing NPE in Interpreter and some better error reporting + tests

### DIFF
--- a/modules/core/src/edu/kit/iti/algover/nuscript/Interpreter.java
+++ b/modules/core/src/edu/kit/iti/algover/nuscript/Interpreter.java
@@ -155,6 +155,13 @@ public final class Interpreter extends DefaultScriptASTVisitor<Void, Void, Scrip
 
     @Override
     public Void visitCases(Cases cases, Void arg) throws ScriptException {
+        if(currentNodes.size() < 2) {
+            throw new ScriptException("Unexpected cases statement", cases);
+        }
+        if(currentNodes.size() != cases.getCases().size() && currentNodes.size() != cases.getCases().size() + 1) {
+            throw new ScriptException("Unexpected number of case statements. Expected " + (currentNodes.size() - 1) + " or " +
+                    currentNodes.size() + " but found " + cases.getCases().size(), cases);
+        }
         for (Case cas : cases.getCases()) {
             ProofNode node = findCase(cas);
             cas.setProofNode(node);
@@ -170,10 +177,10 @@ public final class Interpreter extends DefaultScriptASTVisitor<Void, Void, Scrip
         return null;
     }
 
-    private ProofNode findCase(Case cas) {
+    private ProofNode findCase(Case cas) throws ScriptException {
         String label = Util.stripQuotes(cas.getLabel().getText());
         for (ProofNode node : currentNodes) {
-            if (node.getLabel().equals(label)) {
+            if (label.equals(node.getLabel())) {
                 return node;
             }
         }

--- a/modules/core/test/edu/kit/iti/algover/nuscript/InterpreterTest.java
+++ b/modules/core/test/edu/kit/iti/algover/nuscript/InterpreterTest.java
@@ -10,7 +10,6 @@ import edu.kit.iti.algover.project.Project;
 import edu.kit.iti.algover.proof.PVC;
 import edu.kit.iti.algover.proof.Proof;
 import edu.kit.iti.algover.proof.ProofNode;
-import edu.kit.iti.algover.rules.RuleException;
 import edu.kit.iti.algover.term.FunctionSymbol;
 import edu.kit.iti.algover.term.Sort;
 import edu.kit.iti.algover.util.TestUtil;
@@ -216,6 +215,62 @@ public class InterpreterTest {
         assertThat(exc, Matchers.instanceOf(ParseCancellationException.class));
         assertThat(exc.getMessage(),
                 Matchers.containsString("mismatched input ';' expecting <EOF>"));
+    }
+
+    @Test
+    public void testIllegalCases() throws Exception {
+        Project p = TestUtil.mockProject("method m(b1: bool) ensures b1 && b1 { }");
+        PVC pvc = p.getPVCByName("m/Post");
+        Proof proof = new Proof(pvc);
+        Interpreter interpreter = new Interpreter(proof);
+        interpreter.interpret("cases{}");
+        assertTrue(interpreter.hasFailure());
+        Exception exc = interpreter.getFailures().get(0);
+        assertThat(exc, Matchers.instanceOf(ScriptException.class));
+        assertThat(exc.getMessage(),
+                Matchers.equalToIgnoringCase("Unexpected cases statement"));
+    }
+
+    @Test
+    public void testIllegalCases2() throws Exception {
+        Project p = TestUtil.mockProject("method m(b1: bool) ensures b1 && b1 { }");
+        PVC pvc = p.getPVCByName("m/Post");
+        Proof proof = new Proof(pvc);
+        Interpreter interpreter = new Interpreter(proof);
+        interpreter.interpret("skip; cases{}");
+        assertTrue(interpreter.hasFailure());
+        Exception exc = interpreter.getFailures().get(0);
+        assertThat(exc, Matchers.instanceOf(ScriptException.class));
+        assertThat(exc.getMessage(),
+                Matchers.equalToIgnoringCase("Unexpected cases statement"));
+    }
+
+    @Test
+    public void testIllegalNumberCases() throws Exception {
+        Project p = TestUtil.mockProject("method m(b1: bool) ensures b1 && b1 { }");
+        PVC pvc = p.getPVCByName("m/Post");
+        Proof proof = new Proof(pvc);
+        Interpreter interpreter = new Interpreter(proof);
+        interpreter.interpret("andRight; cases{}");
+        assertTrue(interpreter.hasFailure());
+        Exception exc = interpreter.getFailures().get(0);
+        assertThat(exc, Matchers.instanceOf(ScriptException.class));
+        assertThat(exc.getMessage(),
+                Matchers.equalToIgnoringCase("Unexpected number of case statements. Expected 1 or 2 but found 0"));
+    }
+
+    @Test
+    public void testIllegalNumberCases2() throws Exception {
+        Project p = TestUtil.mockProject("method m(b1: bool) ensures b1 && b1 { }");
+        PVC pvc = p.getPVCByName("m/Post");
+        Proof proof = new Proof(pvc);
+        Interpreter interpreter = new Interpreter(proof);
+        interpreter.interpret("andRight; cases{\"positive\": \"negative\": \"strange\":}");
+        assertTrue(interpreter.hasFailure());
+        Exception exc = interpreter.getFailures().get(0);
+        assertThat(exc, Matchers.instanceOf(ScriptException.class));
+        assertThat(exc.getMessage(),
+                Matchers.equalToIgnoringCase("Unexpected number of case statements. Expected 1 or 2 but found 3"));
     }
 
     @Test


### PR DESCRIPTION
- fixed a NPE which occured when executing the script "cases {}" (i think on any sequent).
- introduced some more informative error messages + corresponding tests IMO